### PR TITLE
testPurgeBufferManagerForParallelStreams fix.

### DIFF
--- a/hadoop-tools/hadoop-azure/.gitignore
+++ b/hadoop-tools/hadoop-azure/.gitignore
@@ -2,4 +2,5 @@
 bin/
 src/test/resources/combinationConfigFiles
 src/test/resources/abfs-combination-test-configs.xml
+src/test/resources/accountSettings/*
 dev-support/testlogs

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestReadBufferManager.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestReadBufferManager.java
@@ -44,8 +44,22 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_READ_AHEAD_QUEUE_DEPTH;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.MIN_BUFFER_SIZE;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.ONE_MB;
+import static org.apache.hadoop.test.LambdaTestUtils.eventually;
 
 public class ITestReadBufferManager extends AbstractAbfsIntegrationTest {
+
+  /**
+   * Time before the JUnit test times out for eventually() clauses
+   * to fail. This copes with slow network connections and debugging
+   * sessions, yet still allows for tests to fail with meaningful
+   * messages.
+   */
+  public static final int TIMEOUT_OFFSET = 5 * 60_000;
+
+  /**
+   * Interval between eventually preobes.
+   */
+  public static final int PROBE_INTERVAL_MILLIS = 1_000;
 
     public ITestReadBufferManager() throws Exception {
     }
@@ -80,9 +94,12 @@ public class ITestReadBufferManager extends AbstractAbfsIntegrationTest {
         }
 
         ReadBufferManager bufferManager = ReadBufferManager.getBufferManager();
-        // verify there is no work in progress or the readahead queue.
-        assertListEmpty("InProgressList", bufferManager.getInProgressCopiedList());
+        // readahead queue is empty.
         assertListEmpty("ReadAheadQueue", bufferManager.getReadAheadQueueCopy());
+
+        // verify the in progress list eventually empties out.
+        eventually(getTestTimeoutMillis() - TIMEOUT_OFFSET, PROBE_INTERVAL_MILLIS, () ->
+          assertListEmpty("InProgressList", bufferManager.getInProgressCopiedList()));
     }
 
     private void assertListEmpty(String listName, List<ReadBuffer> list) {


### PR DESCRIPTION
Fixed testPurgeBufferManagerForParallelStreams.

Taken inspiration from what is there on the apache/trunk. It waits for the inProgressList to get complete.
Since, we are explicitly making it a success, to make test more intelligent, have added a check to test if all the readBuffers from the inProgressList are converted to completedList.

### Description of PR


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

