### PR TITLE
fix namespace fetch for hns account

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -572,6 +572,12 @@ public class AzureBlobFileSystem extends FileSystem
         }
         return dstFileStatus.isDirectory() ? false : true;
       }
+
+      // Non-HNS account need to check dst status on driver side.
+      if (!abfsStore.getIsNamespaceEnabled(tracingContext) && dstFileStatus == null) {
+        dstFileStatus = tryGetFileStatus(qualifiedDstPath, tracingContext);
+      }
+
       try {
         String sourceFileName = src.getName();
         Path adjustedDst = dst;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -196,7 +196,19 @@ public class AzureBlobFileSystem extends FileSystem
     TracingContext tracingContext = new TracingContext(clientCorrelationId,
         fileSystemId, FSOperationType.CREATE_FILESYSTEM, tracingHeaderFormat, listener);
     PrefixMode mode = PrefixMode.DFS;
-    boolean isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
+    boolean isNamespaceEnabled;
+    try {
+      isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
+    } catch (AbfsRestOperationException ex) {
+      /* since the filesystem has not been created. The API for HNS account would
+       * return 404 status.
+       */
+      if(ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+        isNamespaceEnabled = true;
+      } else {
+        throw ex;
+      }
+    }
     if (!isNamespaceEnabled && uri.toString().contains(FileSystemUriSchemes.WASB_DNS_PREFIX)) {
       mode = PrefixMode.BLOB;
     }


### PR DESCRIPTION
We check if account is HNS enabled before creating filesystem. In case of HNS, it throws 404 because for the filesystem we are checking, that is not there on the server. To mitigate this, there is an addition of 404 check. In case 404 is achieved, we will mark it as HNS-enabled account.
+
code from https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java#L444-L447 which is removed from this branch. we need to get this piece of code back to form proper destination for rename api.