### PR TITLE
HADOOP-17377: Add retry for HTTP 429 and HTTP 410 #5273

### DIFF
--- a/hadoop-tools/hadoop-azure/pom.xml
+++ b/hadoop-tools/hadoop-azure/pom.xml
@@ -259,8 +259,23 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -29,12 +29,10 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.Map;
 
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
-
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/oauth2/AzureADAuthenticator.java
@@ -29,10 +29,12 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.Map;
 
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,7 +214,7 @@ public final class AzureADAuthenticator {
       return this.requestId;
     }
 
-    protected HttpException(
+    public HttpException(
         final int httpErrorCode,
         final String requestId,
         final String message,
@@ -340,7 +342,7 @@ public final class AzureADAuthenticator {
         || e instanceof FileNotFoundException);
   }
 
-  private static AzureADToken getTokenSingleCall(String authEndpoint,
+  public static AzureADToken getTokenSingleCall(String authEndpoint,
       String payload, Hashtable<String, String> headers, String httpMethod,
       boolean isMsi)
           throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -58,13 +58,6 @@ public class ExponentialRetryPolicy {
 
   /**
    * Qualifies for retry based on
-   * https://docs.microsoft.com/en-in/azure/virtual-machines/linux/
-   * instance-metadata-service?tabs=windows#errors-and-debugging
-   */
-  private static final int HTTP_GONE = 410;
-
-  /**
-   * Qualifies for retry based on
    * https://learn.microsoft.com/en-us/azure/active-directory/
    * managed-identities-azure-resources/how-to-use-vm-token#error-handling
    */
@@ -133,6 +126,9 @@ public class ExponentialRetryPolicy {
   /**
    * Returns if a request should be retried based on the retry count, current response,
    * and the current strategy.
+   * HTTP status code 410 qualifies for retry based on
+   * https://docs.microsoft.com/en-in/azure/virtual-machines/linux/
+   * instance-metadata-service?tabs=windows#errors-and-debugging
    *
    * @param retryCount The current retry attempt count.
    * @param statusCode The status code of the response, or -1 for socket error.
@@ -142,7 +138,7 @@ public class ExponentialRetryPolicy {
     return retryCount < this.retryCount
         && (statusCode == -1
         || statusCode == HttpURLConnection.HTTP_CLIENT_TIMEOUT
-        || statusCode == HTTP_GONE
+        || statusCode == HttpURLConnection.HTTP_GONE
         || statusCode == HTTP_TOO_MANY_REQUESTS
         || (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
             && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -145,8 +145,8 @@ public class ExponentialRetryPolicy {
         || statusCode == HTTP_GONE
         || statusCode == HTTP_TOO_MANY_REQUESTS
         || (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
-        && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED
-        && statusCode != HttpURLConnection.HTTP_VERSION));
+            && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED
+            && statusCode != HttpURLConnection.HTTP_VERSION));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -57,6 +57,20 @@ public class ExponentialRetryPolicy {
   private static final double MAX_RANDOM_RATIO = 1.2;
 
   /**
+   * Qualifies for retry based on
+   * https://docs.microsoft.com/en-in/azure/virtual-machines/linux/
+   * instance-metadata-service?tabs=windows#errors-and-debugging
+   */
+  private static final int HTTP_GONE = 410;
+
+  /**
+   * Qualifies for retry based on
+   * https://learn.microsoft.com/en-us/azure/active-directory/
+   * managed-identities-azure-resources/how-to-use-vm-token#error-handling
+   */
+  private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+  /**
    *  Holds the random number generator used to calculate randomized backoff intervals
    */
   private final Random randRef = new Random();
@@ -128,9 +142,11 @@ public class ExponentialRetryPolicy {
     return retryCount < this.retryCount
         && (statusCode == -1
         || statusCode == HttpURLConnection.HTTP_CLIENT_TIMEOUT
+        || statusCode == HTTP_GONE
+        || statusCode == HTTP_TOO_MANY_REQUESTS
         || (statusCode >= HttpURLConnection.HTTP_INTERNAL_ERROR
-            && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED
-            && statusCode != HttpURLConnection.HTTP_VERSION));
+        && statusCode != HttpURLConnection.HTTP_NOT_IMPLEMENTED
+        && statusCode != HttpURLConnection.HTTP_VERSION));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ExponentialRetryPolicy.java
@@ -125,7 +125,9 @@ public class ExponentialRetryPolicy {
 
   /**
    * Returns if a request should be retried based on the retry count, current response,
-   * and the current strategy.
+   * and the current strategy. The valid http status code lies in the range of 1xx-5xx.
+   * But an invalid status code might be set due to network or timeout kind of issues.
+   * Such invalid status code also qualify for retry.
    * HTTP status code 410 qualifies for retry based on
    * https://docs.microsoft.com/en-in/azure/virtual-machines/linux/
    * instance-metadata-service?tabs=windows#errors-and-debugging

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsMsiTokenProvider.java
@@ -19,15 +19,21 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Date;
-
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.azurebfs.oauth2.AccessTokenProvider;
+import org.apache.hadoop.fs.azurebfs.oauth2.AzureADAuthenticator;
 import org.apache.hadoop.fs.azurebfs.oauth2.AzureADToken;
 import org.apache.hadoop.fs.azurebfs.oauth2.MsiTokenProvider;
+import org.apache.hadoop.fs.azurebfs.services.ExponentialRetryPolicy;
 
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemConfigurations.DEFAULT_AZURE_OAUTH_TOKEN_FETCH_RETRY_MAX_ATTEMPTS;
+import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.junit.Assume.assumeThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -40,6 +46,7 @@ import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ACCOUNT_OAUTH_MSI_TENANT;
+import static org.mockito.Mockito.times;
 
 /**
  * Test MsiTokenProvider.
@@ -90,4 +97,57 @@ public final class ITestAbfsMsiTokenProvider
     return value.trim();
   }
 
+  /**
+   * Test to verify that token fetch is retried for throttling errors (too many requests 429).
+   * @throws Exception
+   */
+  @Test
+  public void testRetryForThrottling() throws Exception {
+    final int HTTP_TOO_MANY_REQUESTS = 429;
+    AbfsConfiguration conf = getConfiguration();
+
+    // Exception to be thrown with throttling error code 429.
+    AzureADAuthenticator.HttpException httpException
+        = new AzureADAuthenticator.HttpException(HTTP_TOO_MANY_REQUESTS,
+        "abc", "abc", "abc", "abc", "abc");
+
+    String tenantGuid = "abcd";
+    String clientId = "abcd";
+    String authEndpoint = getTrimmedPasswordString(conf,
+        FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT,
+        DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_ENDPOINT);
+    String authority = getTrimmedPasswordString(conf,
+        FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY,
+        DEFAULT_FS_AZURE_ACCOUNT_OAUTH_MSI_AUTHORITY);
+
+    // Mock the getTokenSingleCall to throw exception so the retry logic comes into place.
+    try (MockedStatic<AzureADAuthenticator> adAuthenticator = Mockito.mockStatic(
+        AzureADAuthenticator.class, Mockito.CALLS_REAL_METHODS)) {
+      adAuthenticator.when(
+          () -> AzureADAuthenticator.getTokenSingleCall(Mockito.anyString(),
+              Mockito.anyString(), Mockito.any(), Mockito.anyString(),
+              Mockito.anyBoolean())).thenThrow(httpException);
+
+      // Mock the tokenFetchRetryPolicy to verify retries.
+      ExponentialRetryPolicy exponentialRetryPolicy = Mockito.spy(
+          conf.getOauthTokenFetchRetryPolicy());
+      Field tokenFetchRetryPolicy = AzureADAuthenticator.class.getDeclaredField(
+          "tokenFetchRetryPolicy");
+      tokenFetchRetryPolicy.setAccessible(true);
+      tokenFetchRetryPolicy.set(ExponentialRetryPolicy.class,
+          exponentialRetryPolicy);
+
+      AccessTokenProvider tokenProvider = new MsiTokenProvider(authEndpoint,
+          tenantGuid, clientId, authority);
+      AzureADToken token = null;
+      intercept(AzureADAuthenticator.HttpException.class,
+          tokenProvider::getToken);
+
+      // If the status code doesn't qualify for retry shouldRetry returns false and the loop ends.
+      // It being called multiple times verifies that the retry was done for the throttling status code 429.
+      Mockito.verify(exponentialRetryPolicy,
+              times(DEFAULT_AZURE_OAUTH_TOKEN_FETCH_RETRY_MAX_ATTEMPTS + 1))
+          .shouldRetry(Mockito.anyInt(), Mockito.anyInt());
+    }
+  }
 }


### PR DESCRIPTION
[ABFS: MsiTokenProvider doesn't retry HTTP 429 from the Instance Metadata Service](https://issues.apache.org/jira/browse/HADOOP-17377)

Resolution for the above mentioned issue where we should enable retries for HTTP error code 429 and HTTP error code 410 based on https://learn.microsoft.com/en-in/azure/virtual-machines/linux/instance-metadata-service?tabs=windows#errors-and-debugging and https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#error-handling