### PR TITLE
Config for fallback to DFS

### DIFF
--- a/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
+++ b/hadoop-tools/hadoop-azure/dev-support/testrun-scripts/runtests.sh
@@ -56,6 +56,14 @@ runNonHNSSharedKeyTest()
   triggerRun "NonHNS-SharedKey" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
 }
 
+runNonHNSOAuthTest()
+{
+  accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.nonHnsTestAccountName"]/value' -n $azureTestXmlPath)
+  PROPERTIES=("fs.azure.account.auth.type")
+  VALUES=("OAuth")
+  triggerRun "NonHNS-OAuth" "$accountName" "$runTest" $processCount "$cleanUpTestContainers"
+}
+
 runAppendBlobHNSOAuthTest()
 {
   accountName=$(xmlstarlet sel -t -v '//property[name = "fs.azure.hnsTestAccountName"]/value' -n $azureTestXmlPath)
@@ -130,7 +138,7 @@ done
 
 echo ' '
 echo 'Set the active test combination to run the action:'
-select combo in HNS-OAuth HNS-SharedKey nonHNS-SharedKey AppendBlob-HNS-OAuth AllCombinationsTestRun Quit
+select combo in HNS-OAuth HNS-SharedKey nonHNS-SharedKey NonHNS-OAuth AppendBlob-HNS-OAuth AllCombinationsTestRun Quit
 do
    case $combo in
       HNS-OAuth)
@@ -145,6 +153,10 @@ do
          runNonHNSSharedKeyTest
          break
          ;;
+       NonHNS-OAuth)
+          runNonHNSOAuthTest
+          break
+          ;;
        AppendBlob-HNS-OAuth)
          runAppendBlobHNSOAuthTest
          break
@@ -158,6 +170,7 @@ do
          runHNSOAuthTest
          runHNSSharedKeyTest
          runNonHNSSharedKeyTest
+         runNonHNSOAuthTest
          runAppendBlobHNSOAuthTest ## Keep this as the last run scenario always
          break
          ;;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -359,6 +359,15 @@ public class AbfsConfiguration{
     this.prefixMode = prefixMode;
   }
 
+  @BooleanConfigurationValidatorAnnotation(
+          ConfigurationKey = FS_AZURE_FALLBACK_TO_DFS,
+          DefaultValue = DEFAULT_FS_AZURE_FALLBACK_TO_DFS)
+  private boolean fallbackToDfs;
+
+  public boolean shouldFallbackToDfs() {
+    return this.fallbackToDfs;
+  }
+
   /**
    * Gets the Azure Storage account name corresponding to this instance of configuration.
    * @return the Azure Storage account name

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -360,12 +360,30 @@ public class AbfsConfiguration{
   }
 
   @BooleanConfigurationValidatorAnnotation(
-          ConfigurationKey = FS_AZURE_FALLBACK_TO_DFS,
-          DefaultValue = DEFAULT_FS_AZURE_FALLBACK_TO_DFS)
-  private boolean fallbackToDfs;
+          ConfigurationKey = FS_AZURE_ENABLE_BLOB_ENDPOINT,
+          DefaultValue = DEFAULT_FS_AZURE_ENABLE_BLOBENDPOINT)
+  private boolean enableBlobEndpoint;
 
-  public boolean shouldFallbackToDfs() {
-    return this.fallbackToDfs;
+  public boolean shouldEnableBlobEndPoint() {
+    return this.enableBlobEndpoint;
+  }
+
+  @BooleanConfigurationValidatorAnnotation(
+          ConfigurationKey = FS_AZURE_MKDIRS_FALLBACK_TO_DFS,
+          DefaultValue = DEFAULT_FS_AZURE_MKDIRS_FALLBACK_TO_DFS)
+  private boolean mkdirFallbackToDfs;
+
+  @BooleanConfigurationValidatorAnnotation(
+          ConfigurationKey = FS_AZURE_INGRESS_FALLBACK_TO_DFS,
+          DefaultValue = DEFAULT_FS_AZURE_INGRESS_FALLBACK_TO_DFS)
+  private boolean ingressFallbackToDfs;
+
+  public boolean shouldMkdirFallbackToDfs() {
+    return mkdirFallbackToDfs;
+  }
+
+  public boolean shouldIngressFallbackToDfs() {
+    return ingressFallbackToDfs;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -347,6 +347,7 @@ public class AzureBlobFileSystem extends FileSystem
     }
   }
 
+  // Fallback plan : default to v1 create flow which will hit dfs endpoint. Config to enable: "fs.azure.ingress.fallback.to.dfs".
   @Override
   public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize,
       final short replication, final long blockSize, final Progressable progress) throws IOException {
@@ -436,6 +437,7 @@ public class AzureBlobFileSystem extends FileSystem
         overwrite, bufferSize, replication, blockSize, progress);
   }
 
+  // Fallback plan : default to v1 append flow which will hit dfs endpoint. Config to enable: "fs.azure.ingress.fallback.to.dfs".
   @Override
   public FSDataOutputStream append(final Path f, final int bufferSize, final Progressable progress) throws IOException {
     LOG.debug(
@@ -819,6 +821,7 @@ public class AzureBlobFileSystem extends FileSystem
     }
   }
 
+  // Fallback plan : default to v1 Mkdir flow which will hit dfs endpoint. Config to enable: "fs.azure.mkdirs.fallback.to.dfs".
   @Override
   public boolean mkdirs(final Path f, final FsPermission permission) throws IOException {
     LOG.debug(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -113,6 +113,7 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_LOGGING_LEVEL;
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_LOGGING_LEVEL_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.*;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ENABLE_BLOB_ENDPOINT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.services.RenameAtomicityUtils.SUFFIX;
@@ -182,6 +183,13 @@ public class AzureBlobFileSystem extends FileSystem
             BLOCK_UPLOAD_ACTIVE_BLOCKS_DEFAULT);
     if (blockOutputActiveBlocks < 1) {
       blockOutputActiveBlocks = 1;
+    }
+
+    if (configuration.getBoolean(FS_AZURE_ENABLE_BLOB_ENDPOINT, false)) {
+      if (uri.toString().contains(FileSystemUriSchemes.ABFS_DNS_PREFIX)) {
+        uri = changePrefixFromDfsToBlob(uri);
+        this.uri = uri;
+      }
     }
 
     // AzureBlobFileSystemStore with params in builder.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -385,7 +385,7 @@ public class AzureBlobFileSystem extends FileSystem
       fileOverwrite = true;
     }
 
-    if (!getAbfsStore().getAbfsConfiguration().shouldIngressFallbackToDfs() && prefixMode == PrefixMode.BLOB) {
+    if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -216,8 +216,12 @@ public class AzureBlobFileSystem extends FileSystem
         throw ex;
       }
     }
-    if (!isNamespaceEnabled && uri.toString().contains(FileSystemUriSchemes.WASB_DNS_PREFIX)) {
-      this.prefixMode = PrefixMode.BLOB;
+    if (!isNamespaceEnabled && abfsConfiguration.shouldFallbackToDfs()) {
+      this.prefixMode = PrefixMode.DFS;
+    } else {
+      if (!isNamespaceEnabled && uri.toString().contains(FileSystemUriSchemes.WASB_DNS_PREFIX)) {
+        this.prefixMode = PrefixMode.BLOB;
+      }
     }
     abfsConfiguration.setPrefixMode(this.prefixMode);
     if (abfsConfiguration.getCreateRemoteFileSystemDuringInitialization()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -24,10 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.AccessDeniedException;
 import java.util.Hashtable;
 import java.util.List;
@@ -231,16 +229,6 @@ public class AzureBlobFileSystem extends FileSystem
     if (!isNamespaceEnabled && (abfsConfiguration.shouldEnableBlobEndPoint() ||
             uri.toString().contains(FileSystemUriSchemes.WASB_DNS_PREFIX))) {
       this.prefixMode = PrefixMode.BLOB;
-    }
-    abfsConfiguration.setPrefixMode(this.prefixMode);
-    if (abfsConfiguration.getCreateRemoteFileSystemDuringInitialization()) {
-      if (this.tryGetFileStatus(new Path(AbfsHttpConstants.ROOT_PATH), tracingContext) == null) {
-        try {
-          this.createFileSystem(tracingContext);
-        } catch (AzureBlobFileSystemException ex) {
-          checkException(null, ex, AzureServiceErrorCode.FILE_SYSTEM_ALREADY_EXISTS);
-        }
-      }
     }
     abfsConfiguration.setPrefixMode(this.prefixMode);
     if (abfsConfiguration.getCreateRemoteFileSystemDuringInitialization()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -797,7 +797,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         );
 
       } else {
-        if (getPrefixMode() == PrefixMode.BLOB) {
+        if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
           boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
           op = createPathBlob(relativePath, isNormalBlob, overwrite, metadata, null, tracingContext);
         } else {
@@ -867,7 +867,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       // Trigger a create with overwrite=false first so that eTag fetch can be
       // avoided for cases when no pre-existing file is present (major portion
       // of create file traffic falls into the case of no pre-existing file).
-      if (getPrefixMode() == PrefixMode.BLOB) {
+      if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
         boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
         op = createPathBlob(relativePath, isNormalBlob, false, metadata, null, tracingContext);
       } else {
@@ -896,7 +896,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
         try {
           // overwrite only if eTag matches with the file properties fetched before.
-          if (getPrefixMode() == PrefixMode.BLOB) {
+          if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
             boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
             op = createPathBlob(relativePath, isNormalBlob, true, metadata, eTag, tracingContext);
           } else {
@@ -977,7 +977,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final FsPermission umask, TracingContext tracingContext)
           throws IOException {
     try (AbfsPerfInfo perfInfo = startTracking("createDirectory", "createPath")) {
-      if (getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB) {
+      if (!abfsConfiguration.shouldMkdirFallbackToDfs() && getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB) {
         checkParentChainForFile(path, tracingContext);
 
         HashMap<String, String> metadata = new HashMap<>();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -878,13 +878,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @throws AzureBlobFileSystemException
    */
   private AbfsRestOperation conditionalCreateOverwriteFile(final String relativePath,
-                                                           final FileSystem.Statistics statistics,
-                                                           boolean isNamespaceEnabled,
-                                                           final FsPermission permission,
-                                                           final FsPermission umask,
-                                                           final boolean isAppendBlob,
-                                                           HashMap<String, String> metadata,
-                                                           TracingContext tracingContext) throws AzureBlobFileSystemException {
+      final FileSystem.Statistics statistics,
+      boolean isNamespaceEnabled,
+      final FsPermission permission,
+      final FsPermission umask,
+      final boolean isAppendBlob,
+      HashMap<String, String> metadata,
+      TracingContext tracingContext) throws AzureBlobFileSystemException {
     AbfsRestOperation op;
 
     try {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.VisibleForTesting;
 
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
 import org.apache.hadoop.fs.azurebfs.enums.BlobCopyProgress;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.services.BlobList;
@@ -757,6 +758,31 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return client.createPathBlob(path, isFile, overwrite, metadata, eTag, tracingContext);
   }
 
+  private AbfsRestOperation createFileOrMarker(boolean isNormalBlob, String relativePath, boolean isNamespaceEnabled,
+                                               boolean overwrite, HashMap<String, String> metadata, TracingContext tracingContext,
+                                               FsPermission permission, FsPermission umask, boolean isAppendBlob, String eTag) throws AzureBlobFileSystemException {
+    AbfsRestOperation op;
+    if (!isNormalBlob) {
+      // Marker blob creation flow.
+      if (getPrefixMode() == PrefixMode.DFS || abfsConfiguration.shouldMkdirFallbackToDfs()) {
+        // Marker blob creation is not possible with dfs endpoint.
+        throw new InvalidConfigurationValueException("Incorrect flow for create directory for dfs is hit " + relativePath);
+      } else {
+        op = createPathBlob(relativePath, false, overwrite, metadata, eTag, tracingContext);
+      }
+    } else {
+      // Normal blob creation flow. If config for fallback is not enabled and prefix mode is blob got to blob, else go to dfs.
+      if (getPrefixMode() == PrefixMode.BLOB && !abfsConfiguration.shouldIngressFallbackToDfs()) {
+        op = createPathBlob(relativePath, true, overwrite, metadata, eTag, tracingContext);
+      } else {
+        op = createPath(relativePath, true, overwrite, isNamespaceEnabled ? getOctalNotation(permission) : null,
+                isNamespaceEnabled ? getOctalNotation(umask) : null, isAppendBlob, eTag, tracingContext);
+      }
+    }
+    return op;
+  }
+
+  // Fallback plan : default to v1 create flow which will hit dfs endpoint. Config to enable: "fs.azure.ingress.fallback.to.dfs".
   public OutputStream createFile(final Path path, final FileSystem.Statistics statistics, final boolean overwrite,
       final FsPermission permission, final FsPermission umask,
       TracingContext tracingContext, HashMap<String, String> metadata) throws IOException {
@@ -789,8 +815,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       if (triggerConditionalCreateOverwrite) {
         op = conditionalCreateOverwriteFile(relativePath,
             statistics,
-            isNamespaceEnabled ? getOctalNotation(permission) : null,
-            isNamespaceEnabled ? getOctalNotation(umask) : null,
+            isNamespaceEnabled,
+            permission,
+            umask,
             isAppendBlob,
             metadata,
             tracingContext
@@ -798,14 +825,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
       } else {
         boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
-        if (!isNormalBlob && !abfsConfiguration.shouldMkdirFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-          op = createPathBlob(relativePath, isNormalBlob, overwrite, metadata, null, tracingContext);
-        } else if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-          op = createPathBlob(relativePath, isNormalBlob, overwrite, metadata, null, tracingContext);
-        } else {
-          op = createPath(relativePath, true, overwrite, isNamespaceEnabled ? getOctalNotation(permission) : null,
-                  isNamespaceEnabled ? getOctalNotation(umask) : null, isAppendBlob, null, tracingContext);
-        }
+        op = createFileOrMarker(isNormalBlob, relativePath, isNamespaceEnabled, overwrite, metadata,
+                tracingContext, permission, umask, isAppendBlob, null);
       }
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
 
@@ -857,12 +878,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @throws AzureBlobFileSystemException
    */
   private AbfsRestOperation conditionalCreateOverwriteFile(final String relativePath,
-      final FileSystem.Statistics statistics,
-      final String permission,
-      final String umask,
-      final boolean isAppendBlob,
-      HashMap<String, String> metadata,
-      TracingContext tracingContext) throws AzureBlobFileSystemException {
+                                                           final FileSystem.Statistics statistics,
+                                                           boolean isNamespaceEnabled,
+                                                           final FsPermission permission,
+                                                           final FsPermission umask,
+                                                           final boolean isAppendBlob,
+                                                           HashMap<String, String> metadata,
+                                                           TracingContext tracingContext) throws AzureBlobFileSystemException {
     AbfsRestOperation op;
 
     try {
@@ -870,13 +892,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       // avoided for cases when no pre-existing file is present (major portion
       // of create file traffic falls into the case of no pre-existing file).
       boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
-      if (!isNormalBlob && !abfsConfiguration.shouldMkdirFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-        op = createPathBlob(relativePath, isNormalBlob, false, metadata, null, tracingContext);
-      } else if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-        op = createPathBlob(relativePath, isNormalBlob, false, metadata, null, tracingContext);
-      } else {
-        op = createPath(relativePath, true, false, permission, umask, isAppendBlob, null, tracingContext);
-      }
+      op = createFileOrMarker(isNormalBlob, relativePath, isNamespaceEnabled, false, metadata,
+              tracingContext, permission, umask, isAppendBlob, null);
     } catch (AbfsRestOperationException e) {
       if (e.getStatusCode() == HTTP_CONFLICT) {
         // File pre-exists, fetch eTag
@@ -900,13 +917,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         try {
           // overwrite only if eTag matches with the file properties fetched before.
           boolean isNormalBlob = !checkIsBlobOrMarker(metadata);
-          if (!isNormalBlob && !abfsConfiguration.shouldMkdirFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-            op = createPathBlob(relativePath, isNormalBlob, true, metadata, eTag, tracingContext);
-          } else if (!abfsConfiguration.shouldIngressFallbackToDfs() && getPrefixMode() == PrefixMode.BLOB) {
-            op = createPathBlob(relativePath, isNormalBlob, true, metadata, eTag, tracingContext);
-          } else {
-            op = createPath(relativePath, true, true, permission, umask, isAppendBlob, eTag, tracingContext);
-          }
+          op = createFileOrMarker(isNormalBlob, relativePath, isNamespaceEnabled, true, metadata,
+                  tracingContext, permission, umask, isAppendBlob, eTag);
         } catch (AbfsRestOperationException ex) {
           if (ex.getStatusCode() == HttpURLConnection.HTTP_PRECON_FAILED) {
             // Is a parallel access case, as file with eTag was just queried

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -255,7 +255,12 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
   public static final String FS_AZURE_BLOB_DIR_RENAME_MAX_THREAD = "fs.azure.blob.dir.rename.max.thread";
   public static final String FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS = "fs.azure.blob.copy.progress.poll.wait.millis";
-  public static final String FS_AZURE_FALLBACK_TO_DFS = "fs.azure.fallback.to.dfs";
+
+  public static final String FS_AZURE_ENABLE_BLOB_ENDPOINT = "fs.azure.enable.blob.endpoint";
+  public static final String FS_AZURE_MKDIRS_FALLBACK_TO_DFS = "fs.azure.mkdirs.fallback.to.dfs";
+  public static final String FS_AZURE_INGRESS_FALLBACK_TO_DFS = "fs.azure.ingress.fallback.to.dfs";
+  public static final String FS_AZURE_REDIRECT_DELETE = "fs.azure.redirect.delete";
+  public static final String FS_AZURE_REDIRECT_RENAME = "fs.azure.redirect.rename";
 
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -255,5 +255,7 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
   public static final String FS_AZURE_BLOB_DIR_RENAME_MAX_THREAD = "fs.azure.blob.dir.rename.max.thread";
   public static final String FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS = "fs.azure.blob.copy.progress.poll.wait.millis";
+  public static final String FS_AZURE_FALLBACK_TO_DFS = "fs.azure.fallback.to.dfs";
+
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -118,7 +118,12 @@ public final class FileSystemConfigurations {
 
   public static final int STREAM_ID_LEN = 12;
   public static final boolean DEFAULT_ENABLE_ABFS_LIST_ITERATOR = true;
-  public static final boolean DEFAULT_FS_AZURE_FALLBACK_TO_DFS = false;
+
+  public static final boolean DEFAULT_FS_AZURE_ENABLE_BLOBENDPOINT = false;
+  public static final boolean DEFAULT_FS_AZURE_MKDIRS_FALLBACK_TO_DFS = false;
+  public static final boolean DEFAULT_FS_AZURE_INGRESS_FALLBACK_TO_DFS = false;
+  public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
+  public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
 
   /**
    * Limit of queued block upload operations before writes

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -118,6 +118,7 @@ public final class FileSystemConfigurations {
 
   public static final int STREAM_ID_LEN = 12;
   public static final boolean DEFAULT_ENABLE_ABFS_LIST_ITERATOR = true;
+  public static final boolean DEFAULT_FS_AZURE_FALLBACK_TO_DFS = false;
 
   /**
    * Limit of queued block upload operations before writes

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -404,7 +404,7 @@ public class AbfsClient implements Closeable {
         : SASTokenProvider.CREATE_DIRECTORY_OPERATION;
     appendSASTokenToQuery(path, operation, abfsUriQueryBuilder);
 
-    URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -57,6 +57,8 @@ import org.apache.hadoop.io.IOUtils;
 
 import static org.apache.hadoop.fs.azure.AzureBlobStorageTestAccount.WASB_ACCOUNT_NAME_DOMAIN_SUFFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.*;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.FILE_SYSTEM_NOT_FOUND;
 import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.*;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -320,6 +322,11 @@ public abstract class AbstractAbfsIntegrationTest extends
   }
 
   protected String getTestUrl() {
+    if (abfsConfig.shouldEnableBlobEndPoint()) {
+      if (testUrl.contains(ABFS_DNS_PREFIX)) {
+        testUrl = testUrl.replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
+      }
+    }
     return testUrl;
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -167,6 +167,7 @@ public class ITestAzureBlobFileSystemAppend extends
   public void testRecreateAppendAndFlush() throws IOException {
     final AzureBlobFileSystem fs = getFileSystem();
     Assume.assumeTrue(fs.getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB);
+    Assume.assumeTrue(!fs.getAbfsStore().getAbfsConfiguration().shouldIngressFallbackToDfs());
     fs.create(TEST_FILE_PATH);
     FSDataOutputStream outputStream = fs.append(TEST_FILE_PATH);
     outputStream.write(10);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -304,9 +304,9 @@ public class ITestAzureBlobFileSystemCheckAccess
   }
 
   private void checkPrerequisites() throws Exception {
-    setTestUserFs();
     Assume.assumeTrue(FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT + " is false",
-        isHNSEnabled);
+            isHNSEnabled);
+    setTestUserFs();
     Assume.assumeTrue(FS_AZURE_ENABLE_CHECK_ACCESS + " is false",
         isCheckAccessEnabled);
     checkIfConfigIsSet(FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_ID);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
 import static org.apache.hadoop.fs.CommonPathCapabilities.FS_ACLS;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
 import static org.junit.Assume.assumeTrue;
 
@@ -47,11 +49,16 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
   @Test
   public void ensureAzureBlobFileSystemIsInitialized() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
-    final String accountName = getAccountName();
+    String accountName = getAccountName();
     final String filesystem = getFileSystemName();
 
     String scheme = this.getAuthType() == AuthType.SharedKey ? FileSystemUriSchemes.ABFS_SCHEME
             : FileSystemUriSchemes.ABFS_SECURE_SCHEME;
+    if (fs.getAbfsStore().getAbfsConfiguration().shouldEnableBlobEndPoint()) {
+      if (accountName.contains(ABFS_DNS_PREFIX)) {
+        accountName = accountName.replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
+      }
+    }
     assertEquals(fs.getUri(),
         new URI(scheme,
             filesystem + "@" + accountName,
@@ -63,8 +70,13 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
 
   @Test
   public void ensureSecureAzureBlobFileSystemIsInitialized() throws Exception {
-    final String accountName = getAccountName();
+    String accountName = getAccountName();
     final String filesystem = getFileSystemName();
+    if (getFileSystem().getAbfsStore().getAbfsConfiguration().shouldEnableBlobEndPoint()) {
+      if (accountName.contains(ABFS_DNS_PREFIX)) {
+        accountName = accountName.replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
+      }
+    }
     final URI defaultUri = new URI(FileSystemUriSchemes.ABFS_SECURE_SCHEME,
         filesystem + "@" + accountName,
         null,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestSharedKeyAuth.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestSharedKeyAuth.java
@@ -50,13 +50,12 @@ public class ITestSharedKeyAuth extends AbstractAbfsIntegrationTest {
 
     AbfsClient abfsClient = this.getFileSystem(config).getAbfsClient();
     intercept(AbfsRestOperationException.class,
-        "\"Server failed to authenticate the request. Make sure the value of "
-            + "Authorization header is formed correctly including the "
-            + "signature.\", 403",
-        () -> {
-          abfsClient
-              .getAclStatus(getTestUrl(), getTestTracingContext(getFileSystem(), false));
-        });
+            "\"Server failed to authenticate the request. Make sure the value of "
+                    + "Authorization header is formed correctly including the "
+                    + "signature.\", 403",
+            () -> {
+              this.getFileSystem(config).getAbfsClient();
+            });
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStreamBlob.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsOutputStreamBlob.java
@@ -353,7 +353,8 @@ public final class TestAbfsOutputStreamBlob {
         AbfsOutputStream out = Mockito.spy(getOutputStream(client, getConf()));
         LinkedHashMap<String, BlockStatus> map = Mockito.spy(new LinkedHashMap<>());
         map.put("MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", BlockStatus.SUCCESS);
-        when(out.getMap().containsKey(any())).thenReturn(true);
+        when(out.getMap()).thenReturn(map);
+        when(out.getMap().containsKey(anyString())).thenReturn(true);
 
         final byte[] b = new byte[BUFFER_SIZE];
         new Random().nextBytes(b);


### PR DESCRIPTION
The following changes have been made in this PR 
1. Added a config to enable blob endpoint, so if this config is enabled it doesn't matter the url has blob or dfs the newer api's will be used to talk to the store.
2. Added fallback at API level for mkdirs called as mkdirs fallback and create+append+flush together as one calling it ingress fallback. So fallback here means making the requests go back to dfs endpoint.