### PR TITLE
Mkdir create explicit

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -215,6 +215,11 @@ public class AbfsConfiguration{
       DEFAULT_FS_AZURE_ENABLE_MKDIR_OVERWRITE)
   private boolean mkdirOverwrite;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey =
+          FS_AZURE_ENABLE_BLOB_MKDIR_OVERWRITE, DefaultValue =
+          DEFAULT_FS_AZURE_BLOB_ENABLE_MKDIR_OVERWRITE)
+  private boolean blobMkdirOverwrite;
+
   @StringConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_APPEND_BLOB_KEY,
       DefaultValue = DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES)
   private String azureAppendBlobDirs;
@@ -701,6 +706,10 @@ public class AbfsConfiguration{
 
   public boolean isEnabledMkdirOverwrite() {
     return mkdirOverwrite;
+  }
+
+  public boolean isEnabledBlobMkdirOverwrite() {
+    return blobMkdirOverwrite;
   }
 
   public String getAppendBlobDirs() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -355,6 +356,7 @@ public class AzureBlobFileSystem extends FileSystem
 
     if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
+      mkdirs(qualifiedPath.getParent());
     }
 
     try {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -357,9 +357,7 @@ public class AzureBlobFileSystem extends FileSystem
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
       Path parent = qualifiedPath.getParent();
       if (parent != null && !parent.isRoot()) {
-        try {
           mkdirs(parent);
-        } catch (FileAlreadyExistsException ex) {}
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -355,7 +355,10 @@ public class AzureBlobFileSystem extends FileSystem
 
     if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
-      mkdirs(qualifiedPath.getParent());
+      Path parent = qualifiedPath.getParent();
+      if (!parent.isRoot()) {
+        mkdirs(parent);
+      }
     }
 
     try {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -357,7 +357,9 @@ public class AzureBlobFileSystem extends FileSystem
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
       Path parent = qualifiedPath.getParent();
       if (parent != null && !parent.isRoot()) {
-        mkdirs(parent);
+        try {
+          mkdirs(parent);
+        } catch (FileAlreadyExistsException ex) {}
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -356,7 +356,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
       Path parent = qualifiedPath.getParent();
-      if (!parent.isRoot()) {
+      if (parent != null && !parent.isRoot()) {
         mkdirs(parent);
       }
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1014,21 +1014,20 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param path path to check the hierarchy for.
    * @param tracingContext the tracingcontext.
    */
-  private void checkParentChainForFile(Path path, TracingContext tracingContext, ArrayList<Path> keysToCreateAsFolder) throws IOException {
+  private void checkParentChainForFile(Path path, TracingContext tracingContext,
+                                       List<Path> keysToCreateAsFolder) throws IOException {
     if (directoryExists(path, tracingContext)) {
       return;
     }
     keysToCreateAsFolder.add(path);
     Path current = path.getParent();
-    Path parent = current.getParent();
 
-    while (parent != null) {
+    while (current != null && !current.isRoot()) {
       if (directoryExists(current, tracingContext)) {
         break;
       }
       keysToCreateAsFolder.add(current);
-      current = parent;
-      parent = current.getParent();
+      current = current.getParent();
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1016,30 +1016,19 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    */
   private void checkParentChainForFile(Path path, TracingContext tracingContext,
                                        List<Path> keysToCreateAsFolder) throws IOException {
-    if (directoryExists(path, tracingContext)) {
+    if (checkPathIsDirectory(path, tracingContext)) {
       return;
     }
     keysToCreateAsFolder.add(path);
     Path current = path.getParent();
 
     while (current != null && !current.isRoot()) {
-      if (directoryExists(current, tracingContext)) {
+      if (checkPathIsDirectory(current, tracingContext)) {
         break;
       }
       keysToCreateAsFolder.add(current);
       current = current.getParent();
     }
-  }
-
-  /**
-   * Returns true if path is directory.
-   * @param path path to verify.
-   * @param tracingContext the tracingContext.
-   * @return true or false.
-   * @throws IOException
-   */
-  private boolean directoryExists(Path path, TracingContext tracingContext) throws IOException {
-    return checkPathIsDirectory(path, tracingContext);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -989,10 +989,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
                 permission, umask, tracingContext, metadata);
 
         for (Path pathToCreate: keysToCreateAsFolder) {
-          try {
             createFile(pathToCreate, statistics, blobOverwrite,
                     permission, umask, tracingContext, metadata);
-          } catch (FileAlreadyExistsException ex) {}
         }
         return;
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -984,7 +984,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         HashMap<String, String> metadata = new HashMap<>();
         metadata.put(X_MS_META_HDI_ISFOLDER, TRUE);
         for (Path pathToCreate: keysToCreateAsFolder) {
-          createFile(pathToCreate, statistics, true,
+          createFile(pathToCreate, statistics, false,
                   permission, umask, tracingContext, metadata);
         }
         return;
@@ -1039,9 +1039,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @throws IOException
    */
   private boolean directoryExists(Path path, TracingContext tracingContext) throws IOException {
-    if (getListBlobs(path, null, tracingContext, 2, true).size() > 0) {
-      return true;
-    }
     return checkPathIsDirectory(path, tracingContext);
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -123,6 +123,7 @@ public final class ConfigurationKeys {
    */
   public static final String FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE = "fs.azure.enable.conditional.create.overwrite";
   public static final String FS_AZURE_ENABLE_MKDIR_OVERWRITE = "fs.azure.enable.mkdir.overwrite";
+  public static final String FS_AZURE_ENABLE_BLOB_MKDIR_OVERWRITE = "fs.azure.enable.blob.mkdir.overwrite";
   /** Provides a config to provide comma separated path prefixes on which Appendblob based files are created
    *  Default is empty. **/
   public static final String FS_AZURE_APPEND_BLOB_KEY = "fs.azure.appendblob.directories";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -81,6 +81,7 @@ public final class FileSystemConfigurations {
   public static final String HBASE_ROOT = "/hbase";
   public static final boolean DEFAULT_FS_AZURE_ENABLE_CONDITIONAL_CREATE_OVERWRITE = true;
   public static final boolean DEFAULT_FS_AZURE_ENABLE_MKDIR_OVERWRITE = true;
+  public static final boolean DEFAULT_FS_AZURE_BLOB_ENABLE_MKDIR_OVERWRITE = false;
   public static final String DEFAULT_FS_AZURE_APPEND_BLOB_DIRECTORIES = "";
   public static final String DEFAULT_FS_AZURE_INFINITE_LEASE_DIRECTORIES = "";
   public static final int DEFAULT_LEASE_THREADS = 0;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -473,9 +473,13 @@ public class AbfsClient implements Closeable {
         throw ex;
       }
       if (!isFile && op.getResult().getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
-        if (metadata != null && metadata.containsKey(IS_FOLDER_METADATA_KEY)
-                && metadata.get(IS_FOLDER_METADATA_KEY).equals(TRUE)) {
-          return op; //don't throw ex on mkdirs for existing directory
+         // This ensures that we don't throw ex only for existing directory but if a blob exists we throw exception.
+        tracingContext.setFallbackDFSAppend(tracingContext.getFallbackDFSAppend() + "M");
+        AbfsRestOperation blobProperty = getBlobProperty(new Path(path), tracingContext);
+        final AbfsHttpOperation opResult = blobProperty.getResult();
+        boolean isDirectory = (opResult.getResponseHeader(X_MS_META_HDI_ISFOLDER) != null);
+        if (isDirectory) {
+          return op;
         }
       }
       throw ex;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -152,6 +152,10 @@ public class TracingContext {
     this.fallbackDFSAppend = fallbackDFSAppend;
   }
 
+  public String getFallbackDFSAppend() {
+    return fallbackDFSAppend;
+  }
+
   /**
    * Concatenate all identifiers separated by (:) into a string and set into
    * X_MS_CLIENT_REQUEST_ID header of the http operation

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -191,6 +191,24 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(new Path("a/b/c/d/e"));
   }
 
+  @Test
+  public void testMkdirsWithDelete() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.mkdirs(new Path("a/b"));
+    fs.mkdirs(new Path("a/b/c/d"));
+    fs.delete(new Path("a/b/c/d"));
+    fs.getFileStatus(new Path("a/b/c"));
+  }
+
+  @Test
+  public void testMkdirsWithRename() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.mkdirs(new Path("a/b/c/d"));
+    fs.mkdirs(new Path("e"));
+    fs.delete(new Path("a/b/c/d"));
+    fs.rename(new Path("e"), new Path("a/b/c/d"));
+  }
+
   /**
    * Creation of same directory without overwrite flag should pass.
    * @throws Exception

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -219,6 +219,19 @@ public class ITestAzureBlobFileSystemCreate extends
   }
 
   /**
+   * Create a file with name /dir1 and then mkdirs for /dir1/dir2 should fail.
+   * @throws Exception
+   */
+  @Test
+  public void testFileCreateMkdirsRoot() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.setWorkingDirectory(new Path("/"));
+    final Path p1 = new Path("dir1");
+    fs.create(p1);
+    intercept(IOException.class, () -> fs.mkdirs(new Path("dir1/dir2")));
+  }
+
+  /**
    * Creation of same directory without overwrite flag should pass.
    * @throws Exception
    */

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -264,6 +264,17 @@ public class ITestAzureBlobFileSystemCreate extends
   }
 
   /**
+   * Creation of same directory without overwrite flag should pass.
+   * @throws Exception
+   */
+  @Test
+  public void testCreateSamePathDirectory() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    fs.create(new Path("a"));
+    intercept(IOException.class, () -> fs.mkdirs(new Path("a")));
+  }
+
+  /**
    * Creation of directory with overwrite set to false should not fail according to DFS code.
    * @throws Exception
    */

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.UUID;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -191,6 +192,9 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(new Path("a/b/c/d/e"));
   }
 
+  /*
+    Delete part of a path and validate subpath exists.
+   */
   @Test
   public void testMkdirsWithDelete() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
@@ -198,15 +202,20 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(new Path("a/b/c/d"));
     fs.delete(new Path("a/b/c/d"));
     fs.getFileStatus(new Path("a/b/c"));
+    Assert.assertTrue(fs.exists(new Path("a/b/c")));
   }
 
+  /**
+   * Verify mkdir and rename of parent.
+   */
   @Test
   public void testMkdirsWithRename() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
     fs.mkdirs(new Path("a/b/c/d"));
-    fs.mkdirs(new Path("e"));
+    fs.create(new Path("e/file"));
     fs.delete(new Path("a/b/c/d"));
-    fs.rename(new Path("e"), new Path("a/b/c/d"));
+    Assert.assertTrue(fs.rename(new Path("e"), new Path("a/b/c/d")));
+    Assert.assertTrue(fs.exists(new Path("a/b/c/d/file")));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -61,6 +61,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TRUE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ENABLE_BLOB_MKDIR_OVERWRITE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ENABLE_MKDIR_OVERWRITE;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_META_HDI_ISFOLDER;
 import static org.mockito.ArgumentMatchers.any;
@@ -267,9 +268,9 @@ public class ITestAzureBlobFileSystemCreate extends
    * @throws Exception
    */
   @Test
-  public void testCreateSameDirectoryOverwriteFalse() throws Exception {
+  public void testCreateSameDirectoryOverwriteTrue() throws Exception {
     Configuration configuration = getRawConfiguration();
-    configuration.setBoolean(FS_AZURE_ENABLE_MKDIR_OVERWRITE, false);
+    configuration.setBoolean(FS_AZURE_ENABLE_BLOB_MKDIR_OVERWRITE, true);
     AzureBlobFileSystem fs1 = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     fs1.mkdirs(new Path("a/b/c"));
     fs1.mkdirs(new Path("a/b/c"));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -240,6 +240,18 @@ public class ITestAzureBlobFileSystemCreate extends
   }
 
   /**
+   * Create a file with name /dir1 and then mkdirs for /dir1/dir2 should fail.
+   * @throws Exception
+   */
+  @Test
+  public void testFileCreateMkdirsNonRoot() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final Path p1 = new Path("dir1");
+    fs.create(p1);
+    intercept(IOException.class, () -> fs.mkdirs(new Path("dir1/dir2")));
+  }
+
+  /**
    * Creation of same directory without overwrite flag should pass.
    * @throws Exception
    */

--- a/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
@@ -26,6 +26,7 @@ log4j.logger.org.apache.hadoop.fs.azure.AzureFileSystemThreadPoolExecutor=DEBUG
 log4j.logger.org.apache.hadoop.fs.azure.BlockBlobAppendStream=DEBUG
 log4j.logger.org.apache.hadoop.fs.azurebfs.contracts.services.TracingService=TRACE
 log4j.logger.org.apache.hadoop.fs.azurebfs.services.AbfsClient=DEBUG
+log4j.logger.org.apache.hadoop.fs.azurebfs.services.AbfsIoUtils=DEBUG
 
 # after here: turn off log messages from other parts of the system
 # which only clutter test reports.

--- a/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
+++ b/hadoop-tools/hadoop-azure/src/test/resources/log4j.properties
@@ -26,7 +26,6 @@ log4j.logger.org.apache.hadoop.fs.azure.AzureFileSystemThreadPoolExecutor=DEBUG
 log4j.logger.org.apache.hadoop.fs.azure.BlockBlobAppendStream=DEBUG
 log4j.logger.org.apache.hadoop.fs.azurebfs.contracts.services.TracingService=TRACE
 log4j.logger.org.apache.hadoop.fs.azurebfs.services.AbfsClient=DEBUG
-log4j.logger.org.apache.hadoop.fs.azurebfs.services.AbfsIoUtils=DEBUG
 
 # after here: turn off log messages from other parts of the system
 # which only clutter test reports.


### PR DESCRIPTION
This PR handles the creation of marker blobs recursively.
For example, if a/b exists as directory and we do mkdir for a/b/c/d/e then we create marker blobs for c, d and e.
Same change is done for create. If create call comes for a/b/c/d then create marker for a/b/c and file for d.