### PR TITLE
Rename util json412fix

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1311,7 +1311,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         if (isAtomicRenameKey(source.toUri().getPath())) {
           LOG.debug("source dir {} is an atomicRenameKey",
               source.toUri().getPath());
-          renameAtomicityUtils.preRename(srcBlobProperties);
+          renameAtomicityUtils.preRename(srcBlobProperties, isCreateOnBlobEndpoint());
         } else {
           LOG.debug("source dir {} is not an atomicRenameKey",
               source.toUri().getPath());
@@ -1388,6 +1388,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         }
       }
     } while (shouldContinue);
+  }
+
+  private Boolean isCreateOnBlobEndpoint() {
+    return getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
+        && !"false".equalsIgnoreCase(
+        getAbfsConfiguration().get("fs.azure.ingress.fallback.to.dfs"));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1392,7 +1392,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   private Boolean isCreateOnBlobEndpoint() {
     return getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
-        && !"false".equalsIgnoreCase(
+        && !"true".equalsIgnoreCase(
         getAbfsConfiguration().get("fs.azure.ingress.fallback.to.dfs"));
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1318,7 +1318,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         if (isAtomicRenameKey(source.toUri().getPath())) {
           LOG.debug("source dir {} is an atomicRenameKey",
               source.toUri().getPath());
-          renameAtomicityUtils.preRename(srcBlobProperties, isCreateOnBlobEndpoint());
+          renameAtomicityUtils.preRename(srcBlobProperties, isCreateOperationOnBlobEndpoint());
         } else {
           LOG.debug("source dir {} is not an atomicRenameKey",
               source.toUri().getPath());
@@ -1397,10 +1397,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     } while (shouldContinue);
   }
 
-  private Boolean isCreateOnBlobEndpoint() {
+  private Boolean isCreateOperationOnBlobEndpoint() {
     return getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
-        && !"true".equalsIgnoreCase(
-        getAbfsConfiguration().get("fs.azure.ingress.fallback.to.dfs"));
+        && !getAbfsConfiguration().shouldIngressFallbackToDfs();
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs.services;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -44,6 +45,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
@@ -214,7 +216,8 @@ public class RenameAtomicityUtils {
    * } }</pre>
    * @throws IOException Thrown when fail to write file.
    */
-  public void preRename(List<BlobProperty> blobPropertyList) throws IOException {
+  public void preRename(List<BlobProperty> blobPropertyList,
+      final Boolean createOnBlobEndpoint) throws IOException {
     Path path = getRenamePendingFilePath();
     LOG.debug("Preparing to write atomic rename state to {}", path.toString());
     OutputStream output = null;
@@ -228,7 +231,10 @@ public class RenameAtomicityUtils {
       output.flush();
       output.close();
     } catch (IOException e) {
-      if (e instanceof FileNotFoundException) {
+      if ((!createOnBlobEndpoint && e instanceof FileNotFoundException) || (
+          createOnBlobEndpoint && getWrappedException(e) instanceof AbfsRestOperationException &&
+              ((AbfsRestOperationException) getWrappedException(e)).getStatusCode()
+                  == HttpURLConnection.HTTP_PRECON_FAILED)) {
         /*
          * In case listStatus done on directory before any content could be written,
          * that particular thread running on some worker-node of the cluster would
@@ -247,6 +253,13 @@ public class RenameAtomicityUtils {
               + srcPath.toUri().getPath() + " to " + dstPath.toUri().getPath(),
           e);
     }
+  }
+
+  private Throwable getWrappedException(final IOException e) {
+    if(e.getCause() != null) {
+      return e.getCause().getCause();
+    }
+    return e;
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
@@ -36,7 +36,7 @@ public class RenameNonAtomicUtils extends RenameAtomicityUtils {
 
   @Override
   public void preRename(final List<BlobProperty> blobPropertyList,
-      final Boolean createOnBlobEndpoint)
+      final Boolean isCreateOperationOnBlobEndpoint)
       throws IOException {
 
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
@@ -35,7 +35,8 @@ public class RenameNonAtomicUtils extends RenameAtomicityUtils {
   }
 
   @Override
-  public void preRename(final List<BlobProperty> blobPropertyList)
+  public void preRename(final List<BlobProperty> blobPropertyList,
+      final Boolean createOnBlobEndpoint)
       throws IOException {
 
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -35,9 +35,11 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
@@ -52,6 +54,8 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TRUE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_FALLBACK_TO_DFS;
 import static org.apache.hadoop.fs.azurebfs.services.RenameAtomicityUtils.SUFFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COPY_STATUS_ABORTED;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.COPY_STATUS_FAILED;
@@ -680,12 +684,30 @@ public class ITestAzureBlobFileSystemRename extends
    * ref: <a href="https://issues.apache.org/jira/browse/HADOOP-12678">issue</a>
    */
   @Test
-  public void testHbaseListStatusBeforeRenamePendingFileAppended()
+  public void testHbaseListStatusBeforeRenamePendingFileAppendedWithIngressOnBlob()
       throws Exception {
     final AzureBlobFileSystem fs = this.getFileSystem();
     assumeNonHnsAccountBlobEndpoint(fs);
-    final String failedCopyPath = "hbase/test1/test2/test3/file1";
     fs.setWorkingDirectory(new Path("/"));
+    testHbaseListStatusBeforeRenamePendingFileAppended(fs);
+  }
+
+  @Test
+  public void testHbaseListStatusBeforeRenamePendingFileAppendedWithIngressOnDFS()
+      throws Exception {
+    AzureBlobFileSystem fs = this.getFileSystem();
+    assumeNonHnsAccountBlobEndpoint(fs);
+
+
+    Configuration configuration = Mockito.spy(fs.getAbfsStore().getAbfsConfiguration().getRawConfiguration());
+    configuration.set(FS_AZURE_INGRESS_FALLBACK_TO_DFS, TRUE);
+    fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
+    fs.setWorkingDirectory(new Path("/"));
+    testHbaseListStatusBeforeRenamePendingFileAppended(fs);
+  }
+
+  private void testHbaseListStatusBeforeRenamePendingFileAppended(final AzureBlobFileSystem fs) throws IOException {
+    final String failedCopyPath = "hbase/test1/test2/test3/file1";
     fs.mkdirs(new Path("hbase/test1/test2/test3"));
     fs.create(new Path("hbase/test1/test2/test3/file"));
     fs.create(new Path(failedCopyPath));


### PR DESCRIPTION
For RenameAtomicUtil: RenameJSON file:
Scenario: file has been deleted by parallel thread(because of listStatus() or getFileStatus()) before the RenameJSON could be written and flushed

When we close an outputstream,
on dfs apis, flush API is called which gives 404 if file is deleted.

on blob endpoint, for flush -> putBlockList is called with if-match header. If file is deleted before the api is called, conditional header will fail -> will give 412.

This PR adds the check for 412 if the flush apis are going on blob endpoint.