### PR TITLE
GetBlobProperties on Root Calls GetContainerProperty

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -141,7 +141,6 @@ import org.apache.hadoop.util.SemaphoredDelegatingExecutor;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.http.client.utils.URIBuilder;
 
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.fs.azurebfs.services.RenameAtomicityUtils.SUFFIX;
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.CHAR_EQUALS;
@@ -672,7 +671,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   /**
-   * Gets the property for the contai(filesystem) over Blob Endpoint.
+   * Gets the property for the container(filesystem) over Blob Endpoint.
    *
    * @param tracingContext object of TracingContext required for tracing server calls.
    * @return BlobProperty for the given path

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -653,7 +653,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    */
   BlobProperty getBlobProperty(Path blobPath, TracingContext tracingContext)
       throws AzureBlobFileSystemException {
-    boolean isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
     AbfsRestOperation op;
     BlobProperty blobProperty = new BlobProperty();
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/SASTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/SASTokenProvider.java
@@ -43,6 +43,7 @@ public interface SASTokenProvider {
   String GET_BLOCK_LIST = "get-block-list";
   String GET_PROPERTIES_OPERATION = "get-properties";
   String GET_BLOB_PROPERTIES_OPERATION = "get-blob-properties";
+  String GET_CONTAINER_PROPERTIES_OPERATION = "get-container-properties";
   String LIST_OPERATION = "list";
   String LIST_BLOB_OPERATION = "list-blob";
   String COPY_BLOB_DESTINATION = "copy-blob-dst";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1236,7 +1236,7 @@ public class AbfsClient implements Closeable {
   }
 
   /**
-   * @return the properties returned from server.
+   * @return the blob properties returned from server.
    * @throws AzureBlobFileSystemException in case it is not a 404 error or some other exception
    * which was not able to be retried.
    * */
@@ -1251,6 +1251,29 @@ public class AbfsClient implements Closeable {
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetBlobProperties,
+        this,
+        HTTP_METHOD_HEAD,
+        url,
+        requestHeaders);
+    op.execute(tracingContext);
+    return op;
+  }
+
+  /**
+   * @return the container properties returned from server.
+   * @throws AzureBlobFileSystemException in case it is not a 404 error or some other exception
+   * which was not able to be retried.
+   * */
+  public AbfsRestOperation getContainerProperty(TracingContext tracingContext) throws AzureBlobFileSystemException {
+    AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
+    abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
+    appendSASTokenToQuery("", SASTokenProvider.GET_BLOB_PROPERTIES_OPERATION, abfsUriQueryBuilder);
+
+    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+
+    final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
+    final AbfsRestOperation op = new AbfsRestOperation(
+        AbfsRestOperationType.GetContainerProperties,
         this,
         HTTP_METHOD_HEAD,
         url,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1265,13 +1265,13 @@ public class AbfsClient implements Closeable {
    * which was not able to be retried.
    * */
   public AbfsRestOperation getContainerProperty(TracingContext tracingContext) throws AzureBlobFileSystemException {
-    AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
+    final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
+
+    final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-    appendSASTokenToQuery("", SASTokenProvider.GET_CONTAINER_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
 
-    final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetContainerProperties,
         this,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1267,7 +1267,7 @@ public class AbfsClient implements Closeable {
   public AbfsRestOperation getContainerProperty(TracingContext tracingContext) throws AzureBlobFileSystemException {
     AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-    appendSASTokenToQuery("", SASTokenProvider.GET_BLOB_PROPERTIES_OPERATION, abfsUriQueryBuilder);
+    appendSASTokenToQuery("", SASTokenProvider.GET_CONTAINER_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationType.java
@@ -44,6 +44,7 @@ public enum AbfsRestOperationType {
     LeasePath,
     PutBlob,
     GetBlobProperties,
+    GetContainerProperties,
     PutBlock,
     PutBlockList,
     GetBlockList,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -329,7 +329,7 @@ public class ITestAzureBlobFileSystemCreate extends
     final Path path = new Path("/");
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(path);
-    // Todo: Add assert after fixing getBlobProperties on root @anujmodi2011
+    Assert.assertTrue(fs.getAbfsStore().getBlobProperty(path, Mockito.mock(TracingContext.class)).getIsDirectory());
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -329,7 +329,16 @@ public class ITestAzureBlobFileSystemCreate extends
     final Path path = new Path("/");
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(path);
-    Assert.assertTrue(fs.getAbfsStore().getBlobProperty(path, Mockito.mock(TracingContext.class)).getIsDirectory());
+    if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
+      Assert.assertTrue(fs.getAbfsStore()
+          .getBlobProperty(path, Mockito.mock(TracingContext.class))
+          .getIsDirectory());
+    }
+    else {
+      Assert.assertTrue(fs.getAbfsStore()
+          .getFileStatus(path, Mockito.mock(TracingContext.class))
+          .isDirectory());
+    }
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -329,16 +329,8 @@ public class ITestAzureBlobFileSystemCreate extends
     final Path path = new Path("/");
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(path);
-    if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
-      Assert.assertTrue(fs.getAbfsStore()
-          .getBlobProperty(path, Mockito.mock(TracingContext.class))
-          .getIsDirectory());
-    }
-    else {
-      Assert.assertTrue(fs.getAbfsStore()
-          .getFileStatus(path, Mockito.mock(TracingContext.class))
-          .isDirectory());
-    }
+
+    Assert.assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
@@ -94,6 +94,7 @@ public class DelegationSASGenerator extends SASGenerator {
       case SASTokenProvider.GET_PROPERTIES_OPERATION:
       case SASTokenProvider.GET_BLOCK_LIST:
       case SASTokenProvider.GET_BLOB_PROPERTIES_OPERATION:
+      case SASTokenProvider.GET_CONTAINER_PROPERTIES_OPERATION:
       case SASTokenProvider.READ_OPERATION:
         sp = "r";
         break;


### PR DESCRIPTION
On Blob endpoint. getBlobProperties was failing with Path not exists.
Fix is to call [Get Container Properties](https://learn.microsoft.com/en-us/rest/api/storageservices/get-container-properties?tabs=azure-ad)

This PR fixes that.
Also updated the test case for mkdir on root to assert that root exists as directory.
Behavior is same as that of DFS (GerFileSystemProperty)