### PR TITLE
Producer, consumer design for having listing and renaming in parallel.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
+import org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.thirdparty.com.google.common.base.Preconditions;
@@ -329,6 +330,9 @@ public class AbfsConfiguration{
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey =
       FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, DefaultValue = DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE)
   private int producerQueueMaxSize;
+
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey=FS_AZURE_LEASE_CREATE_NON_RECURSIVE, DefaultValue = DEFAULT_FS_AZURE_LEASE_CREATE_NON_RECURSIVE)
+  private boolean leaseOnCreateNonRecursive;
 
   public AbfsConfiguration(final Configuration rawConfig, String accountName)
       throws IllegalAccessException, InvalidConfigurationValueException, IOException {
@@ -1187,6 +1191,10 @@ public class AbfsConfiguration{
 
   public int getProducerQueueMaxSize() {
     return producerQueueMaxSize;
+  }
+
+  public boolean isLeaseOnCreateNonRecursive() {
+    return leaseOnCreateNonRecursive;
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -246,7 +246,7 @@ public class AbfsConfiguration{
   private int readAheadQueueDepth;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_DIR_RENAME_MAX_THREAD,
-      DefaultValue = 0)
+      DefaultValue = DEFAULT_FS_AZURE_BLOB_RENAME_THREAD)
   private int blobDirRenameMaxThread;
 
   @LongConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -326,6 +326,9 @@ public class AbfsConfiguration{
       FS_AZURE_ENABLE_ABFS_LIST_ITERATOR, DefaultValue = DEFAULT_ENABLE_ABFS_LIST_ITERATOR)
   private boolean enableAbfsListIterator;
 
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_MAX_CONSUMER_LAG, DefaultValue = DEFAULT_FS_AZURE_MAX_CONSUMER_LAG)
+  private int maximumConsumerLag;
+
   public AbfsConfiguration(final Configuration rawConfig, String accountName)
       throws IllegalAccessException, InvalidConfigurationValueException, IOException {
     this.rawConfig = ProviderUtils.excludeIncompatibleCredentialProviders(
@@ -1179,6 +1182,10 @@ public class AbfsConfiguration{
   @VisibleForTesting
   public void setEnableAbfsListIterator(boolean enableAbfsListIterator) {
     this.enableAbfsListIterator = enableAbfsListIterator;
+  }
+
+  public int getMaximumConsumerLag() {
+    return maximumConsumerLag;
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -326,8 +326,9 @@ public class AbfsConfiguration{
       FS_AZURE_ENABLE_ABFS_LIST_ITERATOR, DefaultValue = DEFAULT_ENABLE_ABFS_LIST_ITERATOR)
   private boolean enableAbfsListIterator;
 
-  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_MAX_CONSUMER_LAG, DefaultValue = DEFAULT_FS_AZURE_MAX_CONSUMER_LAG)
-  private int maximumConsumerLag;
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey =
+      FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, DefaultValue = DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE)
+  private int producerQueueMaxSize;
 
   public AbfsConfiguration(final Configuration rawConfig, String accountName)
       throws IllegalAccessException, InvalidConfigurationValueException, IOException {
@@ -1184,8 +1185,8 @@ public class AbfsConfiguration{
     this.enableAbfsListIterator = enableAbfsListIterator;
   }
 
-  public int getMaximumConsumerLag() {
-    return maximumConsumerLag;
+  public int getProducerQueueMaxSize() {
+    return producerQueueMaxSize;
   }
 
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -510,9 +510,9 @@ public class AzureBlobFileSystem extends FileSystem
      */
     AbfsBlobLease abfsBlobLease = null;
     String parentPath = parent.toUri().getPath();
-    if (getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
+    if (getAbfsStore().getPrefixMode() == PrefixMode.BLOB
         && getAbfsStore().isAtomicRenameKey(parentPath)) {
-      if(getAbfsStore().getAbfsConfiguration().isLeaseOnCreateNonRecursive()) {
+      if (getAbfsStore().getAbfsConfiguration().isLeaseOnCreateNonRecursive()) {
         abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
             parentPath, BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -493,10 +493,11 @@ public class AzureBlobFileSystem extends FileSystem
      * rename. The primary use case of the HBase write-ahead log file management.
      */
     AbfsBlobLease abfsBlobLease = null;
+    String parentPath = parent.toUri().getPath();
     if (getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
-        && getAbfsStore().isAtomicRenameKey(parent.toUri().getPath())) {
+        && getAbfsStore().isAtomicRenameKey(parentPath)) {
       abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
-          parent.toUri().getPath(), tracingContext);
+          parentPath, tracingContext);
     }
     final FileStatus parentFileStatus = tryGetFileStatus(parent, tracingContext);
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -511,8 +511,10 @@ public class AzureBlobFileSystem extends FileSystem
     String parentPath = parent.toUri().getPath();
     if (getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
         && getAbfsStore().isAtomicRenameKey(parentPath)) {
-      abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
-          parentPath, BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
+      if(getAbfsStore().getAbfsConfiguration().isLeaseOnCreateNonRecursive()) {
+        abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
+            parentPath, BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
+      }
     }
     final FileStatus parentFileStatus = tryGetFileStatus(parent, tracingContext);
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -114,6 +114,7 @@ import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_LOGGING_LEVEL;
 import static org.apache.hadoop.fs.CommonConfigurationKeys.IOSTATISTICS_LOGGING_LEVEL_DEFAULT;
 import static org.apache.hadoop.fs.azurebfs.AbfsStatistic.*;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.BLOB_LEASE_ONE_MINUTE_DURATION;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ENABLE_BLOB_ENDPOINT;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
@@ -511,7 +512,7 @@ public class AzureBlobFileSystem extends FileSystem
     if (getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
         && getAbfsStore().isAtomicRenameKey(parentPath)) {
       abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
-          parentPath, tracingContext);
+          parentPath, BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
     }
     final FileStatus parentFileStatus = tryGetFileStatus(parent, tracingContext);
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -455,11 +455,13 @@ public class AzureBlobFileSystem extends FileSystem
       fileOverwrite = true;
     }
 
-    if (prefixMode == PrefixMode.BLOB && !blobParentDirPresentChecked) {
+    if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
-      Path parent = qualifiedPath.getParent();
-      if (parent != null && !parent.isRoot()) {
+      if(!blobParentDirPresentChecked) {
+        Path parent = qualifiedPath.getParent();
+        if (parent != null && !parent.isRoot()) {
           mkdirs(parent);
+        }
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -427,6 +427,20 @@ public class AzureBlobFileSystem extends FileSystem
         progress, false);
   }
 
+  /**
+   * Creates a file in the file system with the specified parameters.
+   * @param f the path of the file to create
+   * @param permission the permission of the file
+   * @param overwrite whether to overwrite the existing file if any
+   * @param bufferSize the size of the buffer to be used
+   * @param replication the number of replicas for the file
+   * @param blockSize the size of the block for the file
+   * @param progress the progress indicator for the file creation
+   * @param blobParentDirPresentChecked whether the presence of parent directory
+   * been checked
+   * @return a FSDataOutputStream object that can be used to write to the file
+   * @throws IOException if an error occurs while creating the file
+   */
   private FSDataOutputStream create(final Path f,
       final FsPermission permission,
       final boolean overwrite, final int bufferSize,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -489,7 +489,7 @@ public class AzureBlobFileSystem extends FileSystem
         fileSystemId, FSOperationType.CREATE_NON_RECURSIVE, tracingHeaderFormat,
         listener);
     /*
-     * Get exclusive access to foder if this is a directory designated for atomic
+     * Get exclusive access to folder if this is a directory designated for atomic
      * rename. The primary use case of the HBase write-ahead log file management.
      */
     AbfsBlobLease abfsBlobLease = null;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -424,7 +424,8 @@ public class AzureBlobFileSystem extends FileSystem
   @Override
   public FSDataOutputStream create(final Path f, final FsPermission permission, final boolean overwrite, final int bufferSize,
       final short replication, final long blockSize, final Progressable progress) throws IOException {
-    return create(f, permission, overwrite, bufferSize, replication, blockSize, progress, false);
+    return create(f, permission, overwrite, bufferSize, replication, blockSize,
+        progress, false);
   }
 
   private FSDataOutputStream create(final Path f,
@@ -457,7 +458,7 @@ public class AzureBlobFileSystem extends FileSystem
 
     if (prefixMode == PrefixMode.BLOB) {
       validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
-      if(!blobParentDirPresentChecked) {
+      if (!blobParentDirPresentChecked) {
         Path parent = qualifiedPath.getParent();
         if (parent != null && !parent.isRoot()) {
           mkdirs(parent);
@@ -489,25 +490,29 @@ public class AzureBlobFileSystem extends FileSystem
         fileSystemId, FSOperationType.CREATE_NON_RECURSIVE, tracingHeaderFormat,
         listener);
     /*
-    * Get exclusive access to foder if this is a directory designated for atomic
-    * rename. The primary use case of the HBase write-ahead log file management.
-    */
+     * Get exclusive access to foder if this is a directory designated for atomic
+     * rename. The primary use case of the HBase write-ahead log file management.
+     */
     AbfsBlobLease abfsBlobLease = null;
-    if(getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB && getAbfsStore().isAtomicRenameKey(parent.toUri().getPath())) {
-      abfsBlobLease = new AbfsBlobLease(getAbfsClient(), parent.toUri().getPath(), tracingContext);
+    if (getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB
+        && getAbfsStore().isAtomicRenameKey(parent.toUri().getPath())) {
+      abfsBlobLease = new AbfsBlobLease(getAbfsClient(),
+          parent.toUri().getPath(), tracingContext);
     }
     final FileStatus parentFileStatus = tryGetFileStatus(parent, tracingContext);
 
     if (parentFileStatus == null || !parentFileStatus.isDirectory()) {
-      if(abfsBlobLease != null) {
+      if (abfsBlobLease != null) {
         abfsBlobLease.free();
       }
       throw new FileNotFoundException("Cannot create file "
-          + f.getName() + " because parent folder does not exist or is a file.");
+          + f.getName()
+          + " because parent folder does not exist or is a file.");
     }
 
-    final FSDataOutputStream outputStream = create(f, permission, overwrite, bufferSize, replication, blockSize, progress, true);
-    if(abfsBlobLease != null) {
+    final FSDataOutputStream outputStream = create(f, permission, overwrite,
+        bufferSize, replication, blockSize, progress, true);
+    if (abfsBlobLease != null) {
       abfsBlobLease.free();
     }
     return outputStream;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2130,7 +2130,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           throws AzureBlobFileSystemException {
 
         ListBlobQueue listBlobQueue = new ListBlobQueue(null);
-        new ListBlobProducer(src.toUri().getPath(), client, listBlobQueue, null, tracingContext);
+        String listSrc = src.toUri().getPath() + (src.isRoot() ? EMPTY_STRING : FORWARD_SLASH);
+        new ListBlobProducer(listSrc, client, listBlobQueue, null, tracingContext);
         BlobProperty srcBlobProperty = getBlobProperty(src, tracingContext);
         renameBlobDir(src, destination, tracingContext, listBlobQueue, srcBlobProperty);
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1650,7 +1650,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             renameBlob(
                 blobProperty.getPath(),
                 createDestinationPathForBlobPartOfRenameSrcDir(destination,
-                    source),
+                    blobProperty.getPath(), source),
                 blobLease != null ? blobLease.getLeaseID() : null,
                 tracingContext);
           } catch (AzureBlobFileSystemException e) {
@@ -1674,7 +1674,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
     renameBlob(
         source, createDestinationPathForBlobPartOfRenameSrcDir(destination,
-            source),
+            source, source),
         srcDirBlobLease != null ? srcDirBlobLease.getLeaseID() : null,
         tracingContext);
   }
@@ -1688,15 +1688,16 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * renamed.
    *
    * @param destinationDir destination directory for the rename operation
+   * @param blobPath path of blob inside sourceDir being renamed.
    * @param sourceDir source directory for the rename operation
    *
    * @return translated path for the blob
    */
   private Path createDestinationPathForBlobPartOfRenameSrcDir(final Path destinationDir,
-      final Path sourceDir) {
+      final Path blobPath, final Path sourceDir) {
     String destinationPathStr = destinationDir.toUri().getPath();
     String sourcePathStr = sourceDir.toUri().getPath();
-    String srcBlobPropertyPathStr = sourceDir.toUri().getPath();
+    String srcBlobPropertyPathStr = blobPath.toUri().getPath();
     if (sourcePathStr.equals(srcBlobPropertyPathStr)) {
       return destinationDir;
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1688,6 +1688,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         } catch (InterruptedException | ExecutionException e) {
           LOG.error(String.format("rename from %s to %s failed", source,
               destination), e);
+          renameBlobExecutorService.shutdown();
           throw new RuntimeException(e);
         }
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1558,7 +1558,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         }
 
         renameBlobDir(source, destination, tracingContext, listBlobQueue,
-            blobPropOnSrc, srcDirLease, isAtomicRename);
+            srcDirLease, isAtomicRename);
 
         if (renameAtomicityUtils != null) {
           renameAtomicityUtils.cleanup();
@@ -1615,7 +1615,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final Path destination,
       final TracingContext tracingContext,
       final ListBlobQueue listBlobQueue,
-      final BlobProperty blobPropOnSrc, final AbfsBlobLease srcDirBlobLease,
+      final AbfsBlobLease srcDirBlobLease,
       final Boolean isAtomicRename) throws AzureBlobFileSystemException {
     List<BlobProperty> blobList;
     ListBlobConsumer listBlobConsumer = new ListBlobConsumer(listBlobQueue);
@@ -1650,7 +1650,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             renameBlob(
                 blobProperty.getPath(),
                 createDestinationPathForBlobPartOfRenameSrcDir(destination,
-                    blobProperty, source),
+                    source),
                 blobLease != null ? blobLease.getLeaseID() : null,
                 tracingContext);
           } catch (AzureBlobFileSystemException e) {
@@ -1673,8 +1673,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     renameBlobExecutorService.shutdown();
 
     renameBlob(
-        blobPropOnSrc.getPath(), createDestinationPathForBlobPartOfRenameSrcDir(destination,
-            blobPropOnSrc, source),
+        source, createDestinationPathForBlobPartOfRenameSrcDir(destination,
+            source),
         srcDirBlobLease != null ? srcDirBlobLease.getLeaseID() : null,
         tracingContext);
   }
@@ -1686,17 +1686,17 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   /**
    * Translates the destination path for a blob part of a source directory getting
    * renamed.
+   *
    * @param destinationDir destination directory for the rename operation
-   * @param srcBlobProperty blob part of the source directory getting renamed
    * @param sourceDir source directory for the rename operation
+   *
    * @return translated path for the blob
    */
   private Path createDestinationPathForBlobPartOfRenameSrcDir(final Path destinationDir,
-      final BlobProperty srcBlobProperty,
       final Path sourceDir) {
     String destinationPathStr = destinationDir.toUri().getPath();
     String sourcePathStr = sourceDir.toUri().getPath();
-    String srcBlobPropertyPathStr = srcBlobProperty.getPath().toUri().getPath();
+    String srcBlobPropertyPathStr = sourceDir.toUri().getPath();
     if (sourcePathStr.equals(srcBlobPropertyPathStr)) {
       return destinationDir;
     }
@@ -2567,11 +2567,10 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         String listSrc = listSrcBuilder.toString();
         new ListBlobProducer(listSrc, client, listBlobQueue, null,
             tracingContext);
-        BlobProperty srcBlobProperty = getBlobProperty(src, tracingContext);
         AbfsBlobLease abfsBlobLease = new AbfsBlobLease(client,
             src.toUri().getPath(), BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
         renameBlobDir(src, destination, tracingContext, listBlobQueue,
-            srcBlobProperty, abfsBlobLease, true);
+            abfsBlobLease, true);
       }
     };
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1474,6 +1474,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           LOG.error(
               String.format("Rename of non-directory path from %s to %s failed",
                   source, destination), ex);
+          if(ex instanceof  AbfsRestOperationException && ((AbfsRestOperationException) ex).getStatusCode() == HTTP_NOT_FOUND) {
+            AbfsRestOperationException ex1 = (AbfsRestOperationException) ex;
+            throw new AbfsRestOperationException(
+                ex1.getStatusCode(),
+                AzureServiceErrorCode.SOURCE_PATH_NOT_FOUND.getErrorCode(),
+                ex1.getErrorMessage(), ex1);
+          }
           throw ex;
         }
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1476,7 +1476,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             lease.free();
           }
           LOG.error(
-              String.format("Rename of non-directory path from %s to %s failed",
+              String.format("Rename of path from %s to %s failed",
                   source, destination), ex);
           if (ex instanceof AbfsRestOperationException
               && ((AbfsRestOperationException) ex).getStatusCode()
@@ -1564,7 +1564,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
        * There is no marker-blob, the client has to create marker blob before
        * starting the rename.
        */
-      //create marker file; add in srcBlobProperties;
       LOG.debug("Source {} is a directory but there is no marker-blob",
           source);
       createDirectory(source, null, FsPermission.getDirDefault(),
@@ -1601,7 +1600,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     renameBlobDir(source, destination, tracingContext, listBlobQueue,
         srcDirLease, isAtomicRename);
 
-    if (renameAtomicityUtils != null) {
+    if (isAtomicRename) {
       renameAtomicityUtils.cleanup();
     }
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1437,8 +1437,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     if (getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB) {
       LOG.debug("Rename for src: {} dst: {} for non-HNS blob-endpoint",
           source, destination);
-      final Boolean isSrcExist;
-      final Boolean isSrcDir;
       /*
        * Fetch the list of blobs in the given sourcePath.
        */
@@ -1447,145 +1445,37 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       if (!source.isRoot()) {
         listSrcBuilder.append(FORWARD_SLASH);
       }
-      String listSrc = listSrcBuilder.toString();
+      String listSrc = listSrcBuilder.toString();//block1
       BlobList blobList = client.getListBlobs(null, listSrc, null, null,
               tracingContext).getResult()
           .getBlobList();
       String nextMarker = blobList.getNextMarker();
       List<BlobProperty> srcBlobProperties = blobList.getBlobPropertyList();
 
-      ListBlobQueue listBlobQueue = null;
-      if (srcBlobProperties.size() > 0) {
-        listBlobQueue = new ListBlobQueue(
-            blobList.getBlobPropertyList(),
-            getAbfsConfiguration().getProducerQueueMaxSize(),
-            getAbfsConfiguration().getBlobDirRenameMaxThread());
-      }
-      /*
-       * If nextMarker is non-null, there would be a list of blobs that would
-       * got returned, and listBlobQueue should be non-null. Adding null check
-       *  on listBlobQueue for sanity.
-       */
-      if (listBlobQueue != null && nextMarker != null) {
-        new ListBlobProducer(listSrc,
-            client, listBlobQueue, nextMarker, tracingContext);
-      } else {
-        if (listBlobQueue != null) {
-          listBlobQueue.complete();
-        }
-      }
-
-      BlobProperty blobPropOnSrc;
-      if (srcBlobProperties.size() > 0) {
-        LOG.debug("src {} exists and is a directory", source);
-        isSrcExist = true;
-        isSrcDir = true;
-        /*
-         * Fetch if there is a marker-blob for the source blob.
-         */
-        BlobProperty blobPropOnSrcNullable;
-        try {
-          blobPropOnSrcNullable = getBlobProperty(source, tracingContext);
-        } catch (AbfsRestOperationException ex) {
-          if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-            throw ex;
-          }
-          blobPropOnSrcNullable = null;
-        }
-        if (blobPropOnSrcNullable == null) {
-          /*
-           * There is no marker-blob, the client has to create marker blob before
-           * starting the rename.
-           */
-          //create marker file; add in srcBlobProperties;
-          LOG.debug("Source {} is a directory but there is no marker-blob",
-              source);
-          createDirectory(source, null, FsPermission.getDirDefault(),
-              FsPermission.getUMask(
-                  getAbfsConfiguration().getRawConfiguration()),
-              tracingContext);
-          blobPropOnSrc = new BlobProperty();
-          blobPropOnSrc.setIsDirectory(true);
-          blobPropOnSrc.setPath(source);
-        } else {
-          LOG.debug("Source {} is a directory but there is a marker-blob",
-              source);
-          blobPropOnSrc = blobPropOnSrcNullable;
-        }
-      } else {
+      if (srcBlobProperties.size() > 0) {//block2
+        orchestrateRenameDir(source, destination, renameAtomicityUtils, tracingContext,
+            listSrc,
+            blobList, nextMarker, srcBlobProperties);
+      } else {//block5
         LOG.debug("source {} doesn't have any blob in its hierarchy. Checking"
             + "if there is marker blob for it.", source);
-        try {
-          blobPropOnSrc = getBlobProperty(source, tracingContext);
-        } catch (AbfsRestOperationException ex) {
-          if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-            throw ex;
-          }
-          blobPropOnSrc = null;
-        }
 
-        if (blobPropOnSrc != null) {
-          isSrcExist = true;
-          if (blobPropOnSrc.getIsDirectory()) {
-            LOG.debug("source {} is a marker blob", source);
-            isSrcDir = true;
-            listBlobQueue = new ListBlobQueue(0,0);
-            listBlobQueue.complete();
-          } else {
-            LOG.debug("source {} exists but is not a marker blob", source);
-            isSrcDir = false;
-          }
-        } else {
-          LOG.debug("source {} doesn't exist", source);
-          isSrcExist = false;
-          isSrcDir = false;
-        }
-      }
-
-      if (!isSrcExist) {
-        LOG.info("source {} doesn't exists", source);
-        throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,
-            AzureServiceErrorCode.SOURCE_PATH_NOT_FOUND.getErrorCode(), null,
-            null);
-      }
-      if (isSrcDir) {
-        /*
-         * If source is a directory, all the blobs in the directory have to be
-         * individually copied and then deleted at the source.
-         */
-        LOG.debug("source {} is a directory", source);
-        final AbfsBlobLease srcDirLease;
-        final Boolean isAtomicRename;
-        if (isAtomicRenameKey(source.toUri().getPath())) {
-          LOG.debug("source dir {} is an atomicRenameKey",
-              source.toUri().getPath());
-          srcDirLease = getBlobLease(source.toUri().getPath(),
-              BLOB_LEASE_ONE_MINUTE_DURATION,
-              tracingContext);
-          renameAtomicityUtils.preRename(srcBlobProperties, isCreateOperationOnBlobEndpoint());
-          isAtomicRename = true;
-        } else {
-          srcDirLease = null;
-          isAtomicRename = false;
-          LOG.debug("source dir {} is not an atomicRenameKey",
-              source.toUri().getPath());
-        }
-
-        renameBlobDir(source, destination, tracingContext, listBlobQueue,
-            srcDirLease, isAtomicRename);
-
-        if (renameAtomicityUtils != null) {
-          renameAtomicityUtils.cleanup();
-        }
-      } else {
-        LOG.debug("source {} is not directory", source);
         AbfsLease lease = null;
         if (isAtomicRenameKey(source.toUri().getPath())) {
           lease = getBlobLease(source.toUri().getPath(),
               BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
         }
-        renameBlob(blobPropOnSrc.getPath(), destination, lease, tracingContext
-        );
+        try {
+          renameBlob(source, destination, lease, tracingContext);
+        } catch (AzureBlobFileSystemException ex) {
+          if (lease != null) {
+            lease.free();
+          }
+          LOG.error(
+              String.format("Rename of non-directory path from %s to %s failed",
+                  source, destination), ex);
+          throw ex;
+        }
       }
       LOG.info("Rename from source {} to destination {} done", source,
           destination);
@@ -1623,6 +1513,86 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         }
       }
     } while (shouldContinue);
+  }
+
+  private void orchestrateRenameDir(final Path source,
+      final Path destination,
+      final RenameAtomicityUtils renameAtomicityUtils,
+      final TracingContext tracingContext,
+      final String listSrc,
+      final BlobList blobList,
+      final String nextMarker,
+      final List<BlobProperty> srcBlobProperties) throws IOException {
+    ListBlobQueue listBlobQueue = new ListBlobQueue(
+        blobList.getBlobPropertyList(),
+        getAbfsConfiguration().getProducerQueueMaxSize(),
+        getAbfsConfiguration().getBlobDirRenameMaxThread());
+
+    if (nextMarker != null) {//block3
+      new ListBlobProducer(listSrc,
+          client, listBlobQueue, nextMarker, tracingContext);
+    } else {
+      listBlobQueue.complete();
+    }
+    LOG.debug("src {} exists and is a directory", source);
+    /*
+     * Fetch if there is a marker-blob for the source blob.
+     */
+    BlobProperty blobPropOnSrcNullable;
+    try {
+      blobPropOnSrcNullable = getBlobProperty(source, tracingContext);
+    } catch (AbfsRestOperationException ex) {
+      if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
+        throw ex;
+      }
+      blobPropOnSrcNullable = null;
+    }
+
+    if (blobPropOnSrcNullable == null) {
+      /*
+       * There is no marker-blob, the client has to create marker blob before
+       * starting the rename.
+       */
+      //create marker file; add in srcBlobProperties;
+      LOG.debug("Source {} is a directory but there is no marker-blob",
+          source);
+      createDirectory(source, null, FsPermission.getDirDefault(),
+          FsPermission.getUMask(
+              getAbfsConfiguration().getRawConfiguration()),
+          tracingContext);
+    } else {
+      LOG.debug("Source {} is a directory but there is a marker-blob",
+          source);
+    }
+    /*
+     * If source is a directory, all the blobs in the directory have to be
+     * individually copied and then deleted at the source.
+     */
+    LOG.debug("source {} is a directory", source);
+    final AbfsBlobLease srcDirLease;
+    final Boolean isAtomicRename;
+    if (isAtomicRenameKey(source.toUri().getPath())) {
+      LOG.debug("source dir {} is an atomicRenameKey",
+          source.toUri().getPath());
+      srcDirLease = getBlobLease(source.toUri().getPath(),
+          BLOB_LEASE_ONE_MINUTE_DURATION,
+          tracingContext);
+      renameAtomicityUtils.preRename(srcBlobProperties,
+          isCreateOperationOnBlobEndpoint());
+      isAtomicRename = true;
+    } else {
+      srcDirLease = null;
+      isAtomicRename = false;
+      LOG.debug("source dir {} is not an atomicRenameKey",
+          source.toUri().getPath());
+    }
+
+    renameBlobDir(source, destination, tracingContext, listBlobQueue,
+        srcDirLease, isAtomicRename);
+
+    if (renameAtomicityUtils != null) {
+      renameAtomicityUtils.cleanup();
+    }
   }
 
   @VisibleForTesting

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1689,6 +1689,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           LOG.error(String.format("rename from %s to %s failed", source,
               destination), e);
           renameBlobExecutorService.shutdown();
+          if (srcDirBlobLease != null) {
+            srcDirBlobLease.free();
+          }
           throw new RuntimeException(e);
         }
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1461,11 +1461,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             + "if there is marker blob for it.", source);
 
         AbfsLease lease = null;
-        if (isAtomicRenameKey(source.toUri().getPath())) {
-          lease = getBlobLease(source.toUri().getPath(),
-              BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
-        }
         try {
+          if (isAtomicRenameKey(source.toUri().getPath())) {
+            lease = getBlobLease(source.toUri().getPath(),
+                BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
+          }
           renameBlob(source, destination, lease, tracingContext);
         } catch (AzureBlobFileSystemException ex) {
           if (lease != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -298,14 +298,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         abfsConfiguration.getMaxWriteRequestsToQueue(),
         10L, TimeUnit.SECONDS,
         "abfs-bounded");
-    if (abfsConfiguration.getBlobDirRenameMaxThread() == 0) {
-      renameBlobExecutorService = Executors.newFixedThreadPool(
-          Runtime.getRuntime()
-              .availableProcessors());
-    } else {
-      renameBlobExecutorService = Executors.newFixedThreadPool(
+    renameBlobExecutorService = Executors.newFixedThreadPool(
           abfsConfiguration.getBlobDirRenameMaxThread());
-    }
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1625,6 +1625,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     } while (shouldContinue);
   }
 
+  @VisibleForTesting
   AbfsBlobLease getBlobLease(final String source,
       final Integer blobLeaseOneMinuteDuration,
       final TracingContext tracingContext) throws AzureBlobFileSystemException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1265,22 +1265,23 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       /*
        * Fetch the list of blobs in the given sourcePath.
        */
-      String listSrc = source.toUri().getPath() + (source.isRoot() ? EMPTY_STRING : FORWARD_SLASH);
-      BlobList blobList = client.getListBlobs(null, listSrc, null, tracingContext).getResult()
+      String listSrc = source.toUri().getPath() + (source.isRoot()
+          ? EMPTY_STRING
+          : FORWARD_SLASH);
+      BlobList blobList = client.getListBlobs(null, listSrc, null,
+              tracingContext).getResult()
           .getBlobList();
       String nextMarker = blobList.getNextMarker();
       List<BlobProperty> srcBlobProperties = blobList.getBlobPropertyList();
 
       ListBlobQueue listBlobQueue = new ListBlobQueue(blobList);
-      if(nextMarker != null) {
-       new ListBlobProducer(listSrc,
+      if (nextMarker != null) {
+        new ListBlobProducer(listSrc,
             client, listBlobQueue, nextMarker, tracingContext);
       } else {
         listBlobQueue.complete();
       }
 
-//    List<BlobProperty> srcBlobProperties = getListBlobs(source, null,
-//        tracingContext, null, true);
       BlobProperty blobPropOnSrc;
       if (srcBlobProperties.size() > 0) {
         LOG.debug("src {} exists and is a directory", source);
@@ -1345,7 +1346,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           isSrcDir = false;
         }
       }
-//      srcBlobProperties.add(blobPropOnSrc);
 
       if (!isSrcExist) {
         LOG.info("source {} doesn't exists", source);
@@ -1525,7 +1525,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param destination destination path to which the source has to be moved
    * @param tracingContext tracingContext for tracing the API calls
    * @param sourcePath source path which gets copied to the destination
-   * @param srcBlobLeaseId
+   * @param srcBlobLeaseId leaseId of the srcBlob
    *
    * @throws AzureBlobFileSystemException exception in making server calls
    */
@@ -2169,11 +2169,16 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           throws AzureBlobFileSystemException {
 
         ListBlobQueue listBlobQueue = new ListBlobQueue(null);
-        String listSrc = src.toUri().getPath() + (src.isRoot() ? EMPTY_STRING : FORWARD_SLASH);
-        new ListBlobProducer(listSrc, client, listBlobQueue, null, tracingContext);
+        String listSrc = src.toUri().getPath() + (src.isRoot()
+            ? EMPTY_STRING
+            : FORWARD_SLASH);
+        new ListBlobProducer(listSrc, client, listBlobQueue, null,
+            tracingContext);
         BlobProperty srcBlobProperty = getBlobProperty(src, tracingContext);
-        AbfsBlobLease abfsBlobLease = new AbfsBlobLease(client, src.toUri().getPath(), tracingContext);
-        renameBlobDir(src, destination, tracingContext, listBlobQueue, srcBlobProperty, abfsBlobLease, true);
+        AbfsBlobLease abfsBlobLease = new AbfsBlobLease(client,
+            src.toUri().getPath(), tracingContext);
+        renameBlobDir(src, destination, tracingContext, listBlobQueue,
+            srcBlobProperty, abfsBlobLease, true);
       }
     };
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1265,9 +1265,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       /*
        * Fetch the list of blobs in the given sourcePath.
        */
-      String listSrc = source.toUri().getPath() + (source.isRoot()
-          ? EMPTY_STRING
-          : FORWARD_SLASH);
+      StringBuilder listSrcBuilder = new StringBuilder(source.toUri().getPath());
+      if(!source.isRoot()) {
+        listSrcBuilder.append(FORWARD_SLASH);
+      }
+      String listSrc = listSrcBuilder.toString();
       BlobList blobList = client.getListBlobs(null, listSrc, null,
               tracingContext).getResult()
           .getBlobList();
@@ -2168,10 +2170,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       public void redo(final Path destination, final Path src)
           throws AzureBlobFileSystemException {
 
-        ListBlobQueue listBlobQueue = new ListBlobQueue(null);
-        String listSrc = src.toUri().getPath() + (src.isRoot()
-            ? EMPTY_STRING
-            : FORWARD_SLASH);
+        ListBlobQueue listBlobQueue = new ListBlobQueue();
+        StringBuilder listSrcBuilder = new StringBuilder(src.toUri().getPath());
+        if (!src.isRoot()) {
+          listSrcBuilder.append(FORWARD_SLASH);
+        }
+        String listSrc = listSrcBuilder.toString();
         new ListBlobProducer(listSrc, client, listBlobQueue, null,
             tracingContext);
         BlobProperty srcBlobProperty = getBlobProperty(src, tracingContext);
@@ -2262,7 +2266,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       final boolean isSecure) {
     final URIBuilder uriBuilder = getURIBuilder(accountName, isSecure);
 
-    final String url = uriBuilder.toString() + FORWARD_SLASH
+    final String url = uriBuilder.toString() + AbfsHttpConstants.FORWARD_SLASH
         + fileSystemName;
     return url;
   }
@@ -2374,7 +2378,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   private boolean isKeyForDirectorySet(String key, Set<String> dirSet) {
     for (String dir : dirSet) {
-      if (dir.isEmpty() || key.startsWith(dir + FORWARD_SLASH)) {
+      if (dir.isEmpty() || key.startsWith(dir + AbfsHttpConstants.FORWARD_SLASH)) {
         return true;
       }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -207,8 +207,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   private final ExecutorService renameBlobExecutorService;
 
-  private final Integer ONE_MINUTE = 60;
-
   /**
    * The set of directories where we should store files as append blobs.
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2617,7 +2617,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     if (!enableInfiniteLease) {
       return null;
     }
-    AbfsLease lease = new AbfsLease(client, relativePath, tracingContext);
+    AbfsLease lease = new AbfsLease(client, relativePath, null, tracingContext);
     leaseRefs.put(lease, null);
     return lease;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1265,8 +1265,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       /*
        * Fetch the list of blobs in the given sourcePath.
        */
-      StringBuilder listSrcBuilder = new StringBuilder(source.toUri().getPath());
-      if(!source.isRoot()) {
+      StringBuilder listSrcBuilder = new StringBuilder(
+          source.toUri().getPath());
+      if (!source.isRoot()) {
         listSrcBuilder.append(FORWARD_SLASH);
       }
       String listSrc = listSrcBuilder.toString();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -143,6 +143,7 @@ public final class AbfsHttpConstants {
   public static final String COPY_STATUS_ABORTED = "aborted";
   public static final String COPY_STATUS_FAILED = "failed";
   public static final String HDI_ISFOLDER = "hdi_isfolder";
+  public static final Integer BLOB_LEASE_ONE_MINUTE_DURATION = 60 * 1000;
 
   private AbfsHttpConstants() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/AbfsHttpConstants.java
@@ -143,7 +143,7 @@ public final class AbfsHttpConstants {
   public static final String COPY_STATUS_ABORTED = "aborted";
   public static final String COPY_STATUS_FAILED = "failed";
   public static final String HDI_ISFOLDER = "hdi_isfolder";
-  public static final Integer BLOB_LEASE_ONE_MINUTE_DURATION = 60 * 1000;
+  public static final Integer BLOB_LEASE_ONE_MINUTE_DURATION = 60;
 
   private AbfsHttpConstants() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -265,6 +265,7 @@ public final class ConfigurationKeys {
 
   public static final String FS_AZURE_REDIRECT_DELETE = "fs.azure.redirect.delete";
   public static final String FS_AZURE_REDIRECT_RENAME = "fs.azure.redirect.rename";
+  public static final String FS_AZURE_MAX_CONSUMER_LAG = "fs.azure.max.consumer.lag";
 
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -266,6 +266,7 @@ public final class ConfigurationKeys {
   public static final String FS_AZURE_REDIRECT_DELETE = "fs.azure.redirect.delete";
   public static final String FS_AZURE_REDIRECT_RENAME = "fs.azure.redirect.rename";
   public static final String FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = "fs.azure.producer.queue.max.size";
+  public static final String FS_AZURE_LEASE_CREATE_NON_RECURSIVE = "fs.azure.lease.create.non.recursive";
 
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -265,7 +265,7 @@ public final class ConfigurationKeys {
 
   public static final String FS_AZURE_REDIRECT_DELETE = "fs.azure.redirect.delete";
   public static final String FS_AZURE_REDIRECT_RENAME = "fs.azure.redirect.rename";
-  public static final String FS_AZURE_MAX_CONSUMER_LAG = "fs.azure.max.consumer.lag";
+  public static final String FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = "fs.azure.producer.queue.max.size";
 
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -128,6 +128,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
   public static final int DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = 10000;
+  public static final boolean DEFAULT_FS_AZURE_LEASE_CREATE_NON_RECURSIVE = false;
 
   public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -127,7 +127,7 @@ public final class FileSystemConfigurations {
   // To have functionality similar to drop1 delete is going to wasb by default for now.
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
-  public static final int DEFAULT_FS_AZURE_MAX_CONSUMER_LAG = 7000;
+  public static final int DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = 10000;
 
   public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -133,7 +133,6 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
   public static final int DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = 10000;
   public static final boolean DEFAULT_FS_AZURE_LEASE_CREATE_NON_RECURSIVE = false;
-
   public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -129,6 +129,8 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
   public static final int DEFAULT_FS_AZURE_MAX_CONSUMER_LAG = 7000;
 
+  public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;
+
   /**
    * Limit of queued block upload operations before writes
    * block for an OutputStream. Value: {@value}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -127,6 +127,7 @@ public final class FileSystemConfigurations {
   // To have functionality similar to drop1 delete is going to wasb by default for now.
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
+  public static final int DEFAULT_FS_AZURE_MAX_CONSUMER_LAG = 7000;
 
   /**
    * Limit of queued block upload operations before writes

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpHeaderConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpHeaderConfigurations.java
@@ -68,6 +68,7 @@ public final class HttpHeaderConfigurations {
   public static final String X_MS_LEASE_ACTION = "x-ms-lease-action";
   public static final String X_MS_LEASE_DURATION = "x-ms-lease-duration";
   public static final String X_MS_LEASE_ID = "x-ms-lease-id";
+  public static final String X_MS_SOURCE_LEASE_ID = "x-ms-source-lease-id";
   public static final String X_MS_PROPOSED_LEASE_ID = "x-ms-proposed-lease-id";
   public static final String X_MS_LEASE_BREAK_PERIOD = "x-ms-lease-break-period";
   public static final String X_MS_BLOB_TYPE = "x-ms-blob-type";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/HttpQueryParams.java
@@ -29,6 +29,7 @@ public final class HttpQueryParams {
   public static final String QUERY_PARAM_RESOURCE = "resource";
   public static final String QUERY_PARAM_RESTYPE = "restype";
   public static final String QUERY_PARAM_COMP = "comp";
+  public static final String QUERY_PARAM_COMP_LEASE_VALUE = "lease";
   public static final String QUERY_PARAM_COMP_VALUE_LIST = "list";
   public static final String QUERY_PARAM_PREFIX = "prefix";
   public static final String QUERY_PARAM_MARKER = "marker";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/SASTokenProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/SASTokenProvider.java
@@ -57,6 +57,8 @@ public interface SASTokenProvider {
   String SET_PROPERTIES_OPERATION = "set-properties";
   String WRITE_OPERATION = "write";
 
+  String LEASE_OPERATION = "lease";
+
   /**
    * Initialize authorizer for Azure Blob File System.
    * @param configuration Configuration object

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
@@ -1,0 +1,57 @@
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+
+import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_LEASE_ID;
+
+public class AbfsBlobLease {
+  private String leaseId;
+  private Long leaseRenewLastEpoch;
+  private final TracingContext tracingContext;
+  private final AbfsClient client;
+  private final String path;
+  private final Integer ONE_MINUTE = 60;
+  private final Long RENEW_TIME = 30 * 1_000L;
+  private Boolean freed = false;
+
+  public AbfsBlobLease(AbfsClient client, String path, TracingContext tracingContext) throws
+      AzureBlobFileSystemException {
+    this.client = client;
+    this.path = path;
+    this.tracingContext = tracingContext;
+    AbfsRestOperation op = client.acquireBlobLease(path, ONE_MINUTE, tracingContext);
+    extractLeaseInfo(op);
+  }
+
+  private void extractLeaseInfo(final AbfsRestOperation op) {
+    leaseId = op.getResult().getResponseHeader(X_MS_LEASE_ID);
+    leaseRenewLastEpoch = System.currentTimeMillis();
+  }
+
+  public String getLeaseId() {
+    return leaseId;
+  }
+
+  public void renewIfRequired() throws AzureBlobFileSystemException {
+    if(System.currentTimeMillis() - leaseRenewLastEpoch >= RENEW_TIME) {
+      renew();
+    }
+  }
+
+  private synchronized void renew() throws AzureBlobFileSystemException {
+    if(System.currentTimeMillis() - leaseRenewLastEpoch < RENEW_TIME) {
+      return;
+    }
+    AbfsRestOperation op = client.renewBlobLease(path, leaseId, tracingContext);
+    extractLeaseInfo(op);
+  }
+
+  public synchronized void free() throws AzureBlobFileSystemException {
+    if(freed) {
+      return;
+    }
+    client.releaseBlobLease(path, leaseId, tracingContext);
+    freed = true;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobLease.java
@@ -33,12 +33,15 @@ public class AbfsBlobLease {
   private final Long RENEW_TIME = 30 * 1_000L;
   private Boolean freed = false;
 
-  public AbfsBlobLease(AbfsClient client, String path, TracingContext tracingContext) throws
+  public AbfsBlobLease(AbfsClient client,
+      String path,
+      TracingContext tracingContext) throws
       AzureBlobFileSystemException {
     this.client = client;
     this.path = path;
     this.tracingContext = tracingContext;
-    AbfsRestOperation op = client.acquireBlobLease(path, ONE_MINUTE, tracingContext);
+    AbfsRestOperation op = client.acquireBlobLease(path, ONE_MINUTE,
+        tracingContext);
     extractLeaseInfo(op);
   }
 
@@ -52,13 +55,13 @@ public class AbfsBlobLease {
   }
 
   public void renewIfRequired() throws AzureBlobFileSystemException {
-    if(System.currentTimeMillis() - leaseRenewLastEpoch >= RENEW_TIME) {
+    if (System.currentTimeMillis() - leaseRenewLastEpoch >= RENEW_TIME) {
       renew();
     }
   }
 
   private synchronized void renew() throws AzureBlobFileSystemException {
-    if(System.currentTimeMillis() - leaseRenewLastEpoch < RENEW_TIME) {
+    if (System.currentTimeMillis() - leaseRenewLastEpoch < RENEW_TIME) {
       return;
     }
     AbfsRestOperation op = client.renewBlobLease(path, leaseId, tracingContext);
@@ -66,7 +69,7 @@ public class AbfsBlobLease {
   }
 
   public synchronized void free() throws AzureBlobFileSystemException {
-    if(freed) {
+    if (freed) {
       return;
     }
     client.releaseBlobLease(path, leaseId, tracingContext);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -616,7 +616,7 @@ public class AbfsClient implements Closeable {
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.LeasePath,
         this,
-        HTTP_METHOD_POST,
+        HTTP_METHOD_PUT,
         url,
         requestHeaders);
     op.execute(tracingContext);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1283,7 +1283,7 @@ public class AbfsClient implements Closeable {
         srcBlobRelativePath,
         abfsUriQueryBuilderSrc.toString()).toString();
     List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
-    if(srcLeaseId != null) {
+    if (srcLeaseId != null) {
       requestHeaders.add(new AbfsHttpHeader(X_MS_SOURCE_LEASE_ID, srcLeaseId));
     }
     requestHeaders.add(new AbfsHttpHeader(X_MS_COPY_SOURCE, sourcePathUrl));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsLease.java
@@ -18,10 +18,22 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
+import org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 public class AbfsDfsLease extends AbfsLease {
+
+  public AbfsDfsLease(final AbfsClient client,
+      final String path,
+      final int acquireMaxRetries,
+      final int acquireRetryInterval,
+      final Integer leaseDuration,
+      final TracingContext tracingContext) throws AzureBlobFileSystemException {
+    super(client, path, acquireMaxRetries, acquireRetryInterval, leaseDuration,
+        tracingContext);
+  }
 
   public AbfsDfsLease(final AbfsClient client,
       final String path,
@@ -32,9 +44,10 @@ public class AbfsDfsLease extends AbfsLease {
 
   @Override
   String callRenewLeaseAPI(final String path,
-      final String s,
-      final TracingContext tracingContext) {
-    return null;
+      final String leaseId,
+      final TracingContext tracingContext) throws AzureBlobFileSystemException {
+    AbfsRestOperation op = client.renewLease(path, leaseId, tracingContext);
+    return op.getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsDfsLease.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+
+public class AbfsDfsLease extends AbfsLease {
+
+  public AbfsDfsLease(final AbfsClient client,
+      final String path,
+      final Integer leaseDuration,
+      final TracingContext tracingContext) throws AzureBlobFileSystemException {
+    super(client, path, leaseDuration, tracingContext);
+  }
+
+  @Override
+  String callRenewLeaseAPI(final String path,
+      final String s,
+      final TracingContext tracingContext) {
+    return null;
+  }
+
+  @Override
+  AbfsRestOperation callAcquireLeaseAPI(final String path, final Integer leaseDuration,
+      final TracingContext tracingContext)
+      throws AzureBlobFileSystemException {
+    return client.acquireLease(path,
+        leaseDuration, tracingContext);
+  }
+
+  @Override
+  void callReleaseLeaseAPI(final String path, final String leaseID, final TracingContext tracingContext)
+      throws AzureBlobFileSystemException {
+    client.releaseLease(path, leaseID, tracingContext);
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -90,7 +90,8 @@ public abstract class AbfsLease {
   /**
    * @param client client object for making server calls
    * @param path path on which lease has to be acquired, renewed and freed in future
-   * @param leaseDuration duration for which lease to be taken in seconds
+   * @param leaseDuration duration for which lease to be taken in seconds. If given
+   * <code>null</code>, it will be taken as infinte-lease.
    * @param tracingContext for tracing server calls
    *
    * @throws AzureBlobFileSystemException exception while calling acquireLease API
@@ -148,8 +149,10 @@ public abstract class AbfsLease {
     if (future != null && !future.isDone()) {
       throw new LeaseException(ERR_LEASE_FUTURE_EXISTS);
     }
-    if(leaseDuration != null) {
-      leaseID.set(callAcquireLeaseAPI(path, leaseDuration, tracingContext).getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID));
+    if (leaseDuration != null) {
+      leaseID.set(
+          callAcquireLeaseAPI(path, leaseDuration, tracingContext).getResult()
+              .getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID));
       spawnLeaseRenewTimer(path, leaseDuration * 1000);
       return;
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -174,14 +174,18 @@ public abstract class AbfsLease {
     timer.schedule(new TimerTask() {
       @Override
       public void run() {
-        leaseID.set(callRenewLeaseAPI(path, leaseID.get(), tracingContext));
+        try {
+          leaseID.set(callRenewLeaseAPI(path, leaseID.get(), tracingContext));
+        } catch (AzureBlobFileSystemException e) {
+          throw new RuntimeException(e);
+        }
       }
     }, leaseDuration / 2);
   }
 
   abstract String callRenewLeaseAPI(final String path,
       final String s,
-      final TracingContext tracingContext);
+      final TracingContext tracingContext) throws AzureBlobFileSystemException;
 
   abstract AbfsRestOperation callAcquireLeaseAPI(final String path,
       final Integer leaseDuration,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -70,6 +70,7 @@ public final class AbfsLease {
   private volatile Throwable exception = null;
   private volatile int acquireRetryCount = 0;
   private volatile ListenableScheduledFuture<AbfsRestOperation> future = null;
+  private final Integer leaseDuration;
 
   public static class LeaseException extends AzureBlobFileSystemException {
     public LeaseException(Throwable t) {
@@ -81,18 +82,21 @@ public final class AbfsLease {
     }
   }
 
-  public AbfsLease(AbfsClient client, String path, TracingContext tracingContext) throws AzureBlobFileSystemException {
+  public AbfsLease(AbfsClient client, String path,
+      final Integer leaseDuration,
+      TracingContext tracingContext) throws AzureBlobFileSystemException {
     this(client, path, DEFAULT_LEASE_ACQUIRE_MAX_RETRIES,
-        DEFAULT_LEASE_ACQUIRE_RETRY_INTERVAL, tracingContext);
+        DEFAULT_LEASE_ACQUIRE_RETRY_INTERVAL, leaseDuration, tracingContext);
   }
 
   @VisibleForTesting
   public AbfsLease(AbfsClient client, String path, int acquireMaxRetries,
-      int acquireRetryInterval, TracingContext tracingContext) throws AzureBlobFileSystemException {
+      int acquireRetryInterval, final Integer leaseDuration, TracingContext tracingContext) throws AzureBlobFileSystemException {
     this.leaseFreed = false;
     this.client = client;
     this.path = path;
     this.tracingContext = tracingContext;
+    this.leaseDuration = leaseDuration;
 
     if (client.getNumLeaseThreads() < 1) {
       throw new LeaseException(ERR_NO_LEASE_THREADS);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -192,8 +192,7 @@ public abstract class AbfsLease {
       public void run() {
         try {
           leaseID.set(callRenewLeaseAPI(path, leaseID.get(), tracingContext));
-        } catch (AzureBlobFileSystemException e) {
-          throw new RuntimeException(e);
+        } catch (AzureBlobFileSystemException ignored) {
         }
       }
     }, leaseDuration / 2, leaseDuration / 2);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -87,6 +87,14 @@ public abstract class AbfsLease {
     }
   }
 
+  /**
+   * @param client client object for making server calls
+   * @param path path on which lease has to be acquired, renewed and freed in future
+   * @param leaseDuration duration for which lease to be taken in seconds
+   * @param tracingContext for tracing server calls
+   *
+   * @throws AzureBlobFileSystemException exception while calling acquireLease API
+   */
   public AbfsLease(AbfsClient client, String path,
       final Integer leaseDuration,
       TracingContext tracingContext) throws AzureBlobFileSystemException {
@@ -142,7 +150,7 @@ public abstract class AbfsLease {
     }
     if(leaseDuration != null) {
       leaseID.set(callAcquireLeaseAPI(path, leaseDuration, tracingContext).getResult().getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID));
-      spawnLeaseRenewTimer(path, leaseDuration);
+      spawnLeaseRenewTimer(path, leaseDuration * 1000);
       return;
     }
     future = client.schedule(() -> callAcquireLeaseAPI(path,
@@ -185,7 +193,7 @@ public abstract class AbfsLease {
           throw new RuntimeException(e);
         }
       }
-    }, leaseDuration / 2);
+    }, leaseDuration / 2, leaseDuration / 2);
   }
 
   abstract String callRenewLeaseAPI(final String path,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -221,9 +221,7 @@ public abstract class AbfsLease {
       if (future != null && !future.isDone()) {
         future.cancel(true);
       }
-      if (timer != null) {
-        timer.cancel();
-      }
+      cancelTimer();
       TracingContext tracingContext = new TracingContext(this.tracingContext);
       tracingContext.setOperation(FSOperationType.RELEASE_LEASE);
       callReleaseLeaseAPI(path, leaseID.get(), tracingContext);
@@ -235,6 +233,12 @@ public abstract class AbfsLease {
       // make sure to record that we freed the lease
       leaseFreed = true;
       LOG.debug("Freed lease {} on {}", leaseID, path);
+    }
+  }
+
+  public void cancelTimer() {
+    if (timer != null) {
+      timer.cancel();
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationType.java
@@ -42,6 +42,7 @@ public enum AbfsRestOperationType {
     DeletePath,
     CheckAccess,
     LeasePath,
+    LeaseBlob,
     PutBlob,
     GetBlobProperties,
     GetContainerProperties,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -3,19 +3,22 @@ package org.apache.hadoop.fs.azurebfs.services;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 
 public class ListBlobConsumer {
+
   private final ListBlobQueue listBlobQueue;
+
   public ListBlobConsumer(final ListBlobQueue listBlobQueue) {
     this.listBlobQueue = listBlobQueue;
   }
 
   public BlobList consume() throws AzureBlobFileSystemException {
-    if(listBlobQueue.getFailed()) {
+    if (listBlobQueue.getException() != null) {
       throw listBlobQueue.getException();
     }
     return listBlobQueue.dequeue();
   }
 
   public Boolean isCompleted() {
-    return listBlobQueue.getIsCompleted() && listBlobQueue.getConsumerLag() == 0;
+    return listBlobQueue.getIsCompleted()
+        && listBlobQueue.getConsumerLag() == 0;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+
+public class ListBlobConsumer {
+  private final ListBlobQueue listBlobQueue;
+  public ListBlobConsumer(final ListBlobQueue listBlobQueue) {
+    this.listBlobQueue = listBlobQueue;
+  }
+
+  public BlobList consume() throws AzureBlobFileSystemException {
+    if(listBlobQueue.getFailed()) {
+      throw listBlobQueue.getException();
+    }
+    return listBlobQueue.dequeue();
+  }
+
+  public Boolean isCompleted() {
+    return listBlobQueue.getIsCompleted();
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -16,6 +16,6 @@ public class ListBlobConsumer {
   }
 
   public Boolean isCompleted() {
-    return listBlobQueue.getIsCompleted();
+    return listBlobQueue.getIsCompleted() && listBlobQueue.getConsumerLag() == 0;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.util.List;
+
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 
 public class ListBlobConsumer {
@@ -28,7 +30,7 @@ public class ListBlobConsumer {
     this.listBlobQueue = listBlobQueue;
   }
 
-  public BlobList consume() throws AzureBlobFileSystemException {
+  public List<BlobProperty> consume() throws AzureBlobFileSystemException {
     if (listBlobQueue.getException() != null) {
       throw listBlobQueue.getException();
     }
@@ -37,6 +39,6 @@ public class ListBlobConsumer {
 
   public Boolean isCompleted() {
     return listBlobQueue.getIsCompleted()
-        && listBlobQueue.getConsumerLag() == 0;
+        && listBlobQueue.size() == 0;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -42,6 +42,7 @@ public class ListBlobProducer {
     this.client = abfsClient;
     this.tracingContext = tracingContext;
     this.listBlobQueue = listBlobQueue;
+    listBlobQueue.setProducer(this);
     this.nextMarker = initNextMarker;
     new Thread(() -> {
       while (true) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -19,7 +19,7 @@ public class ListBlobProducer {
     this.nextMarker = initNextMarker;
     new Thread(() -> {
       while(true) {
-        if(listBlobQueue.getConsumerLag() > 7000) {
+        if(listBlobQueue.getConsumerLag() > client.getAbfsConfiguration().getMaximumConsumerLag()) {
           continue;
         }
         AbfsRestOperation op = null;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -1,0 +1,40 @@
+package org.apache.hadoop.fs.azurebfs.services;
+
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+
+public class ListBlobProducer {
+  private final AbfsClient client;
+  private final ListBlobQueue listBlobQueue;
+  private final String src;
+  private final TracingContext tracingContext;
+  private String nextMarker;
+
+  public ListBlobProducer(final String src, final AbfsClient abfsClient,
+      final ListBlobQueue listBlobQueue, TracingContext tracingContext) {
+    this.src = src;
+    this.client = abfsClient;
+    this.tracingContext = tracingContext;
+    this.listBlobQueue = listBlobQueue;
+    new Thread(() -> {
+      while(true) {
+        if(listBlobQueue.getConsumerLag() > 7000) {
+          continue;
+        }
+        AbfsRestOperation op = null;
+        try {
+          op = client.getListBlobs(nextMarker, src, null, tracingContext);
+        } catch (AzureBlobFileSystemException ex) {
+          listBlobQueue.setFailed(ex);
+          throw new RuntimeException(ex);
+        }
+        BlobList blobList = op.getResult().getBlobList();
+        nextMarker = blobList.getNextMarker();
+        listBlobQueue.enqueue(blobList);
+        if(nextMarker == null) {
+          break;
+        }
+      }
+    }).start();
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.services;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -33,6 +33,7 @@ public class ListBlobProducer {
         nextMarker = blobList.getNextMarker();
         listBlobQueue.enqueue(blobList);
         if(nextMarker == null) {
+          listBlobQueue.complete();
           break;
         }
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -21,6 +21,27 @@ package org.apache.hadoop.fs.azurebfs.services;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
+/**
+ * ListBlob API can give maximum of 5000 blobs. If there are (~n*5000) blobs, the
+ * client would need to call the listBlob API n times. This would have two consequences:
+ * <ol>
+ *   <li>
+ *     The consumer of the result of lists of blob would have to wait until all
+ *     the blobs are received. The consumer could have used the time to start
+ *     processing the blobs already in memory. The wait for receiving all the blobs
+ *     would lead the processing more time. Lets say consumer need m time-units to process
+ *     one blob. Lets say that client needs t time to get all the blobs. If consumer
+ *     wait for all the blobs to be received, the total time taken would be:
+ *     <pre>t + (n * m)</pre>
+ *     Now, lets assume that consumer in parallel work on the available the blobs,
+ *     time taken would be:
+ *     <pre>t + ((n - t/m) * m)</pre>
+ *   </li>
+ *   <li>
+ *
+ *   </li>
+ * </ol>
+ */
 public class ListBlobProducer {
 
   private final AbfsClient client;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -11,11 +11,12 @@ public class ListBlobProducer {
   private String nextMarker;
 
   public ListBlobProducer(final String src, final AbfsClient abfsClient,
-      final ListBlobQueue listBlobQueue, TracingContext tracingContext) {
+      final ListBlobQueue listBlobQueue, final String initNextMarker, TracingContext tracingContext) {
     this.src = src;
     this.client = abfsClient;
     this.tracingContext = tracingContext;
     this.listBlobQueue = listBlobQueue;
+    this.nextMarker = initNextMarker;
     new Thread(() -> {
       while(true) {
         if(listBlobQueue.getConsumerLag() > 7000) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -89,7 +89,7 @@ public class ListBlobProducer {
           op = client.getListBlobs(nextMarker, src, null, tracingContext);
         } catch (AzureBlobFileSystemException ex) {
           listBlobQueue.setFailed(ex);
-          throw new RuntimeException(ex);
+          return;
         }
         BlobList blobList = op.getResult().getBlobList();
         nextMarker = blobList.getNextMarker();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -86,7 +86,7 @@ public class ListBlobProducer {
         }
         AbfsRestOperation op = null;
         try {
-          op = client.getListBlobs(nextMarker, src, maxResult, tracingContext);
+          op = client.getListBlobs(nextMarker, src, null, maxResult, tracingContext);
         } catch (AzureBlobFileSystemException ex) {
           listBlobQueue.setFailed(ex);
           return;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.ArrayDeque;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -17,7 +17,9 @@ public class ListBlobQueue {
   private AzureBlobFileSystemException failureFromProducer;
 
   public ListBlobQueue(BlobList initBlobList) {
-    blobLists.add(initBlobList);
+    if(initBlobList != null) {
+      enqueue(initBlobList);
+    }
   }
 
   void setFailed(AzureBlobFileSystemException failure) {
@@ -29,7 +31,7 @@ public class ListBlobQueue {
     return failed;
   }
 
-  void complete() {
+  public void complete() {
     isCompleted = true;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -16,6 +16,10 @@ public class ListBlobQueue {
 
   private AzureBlobFileSystemException failureFromProducer;
 
+  public ListBlobQueue(BlobList initBlobList) {
+    blobLists.add(initBlobList);
+  }
+
   void setFailed(AzureBlobFileSystemException failure) {
     failed = true;
     failureFromProducer = failure;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -47,12 +47,22 @@ public class ListBlobQueue {
   private final int maxSize;
   private final int maxConsumedBlobCount;
 
+  /**
+   * @param maxSize maxSize of the queue.
+   * @param maxConsumedBlobCount maximum number of blobs that would be returned
+   * by {@link #dequeue()} method.
+   */
   public ListBlobQueue(int maxSize, int maxConsumedBlobCount) {
     blobLists = new ArrayDeque<>(maxSize);
     this.maxSize = maxSize;
     this.maxConsumedBlobCount = maxConsumedBlobCount;
   }
 
+  /**
+   * @param maxSize maxSize of the queue.
+   * @param maxConsumedBlobCount maximum number of blobs that would be returned
+   * by {@link #dequeue()} method.
+   */
   public ListBlobQueue(List<BlobProperty> initBlobList, int maxSize, int maxConsumedBlobCount) {
     this(maxSize, maxConsumedBlobCount);
     if (initBlobList != null) {
@@ -89,7 +99,7 @@ public class ListBlobQueue {
   public List<BlobProperty> dequeue() {
     List<BlobProperty> blobProperties = new ArrayList<>();
     int counter = 0;
-    while(counter < maxConsumedBlobCount && blobLists.size() > 0) {
+    while (counter < maxConsumedBlobCount && blobLists.size() > 0) {
       blobProperties.add(blobLists.poll());
       counter++;
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -35,7 +35,7 @@ public class ListBlobQueue {
     isCompleted = true;
   }
 
-  Boolean getIsCompleted() {
+  public Boolean getIsCompleted() {
     return isCompleted;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -35,9 +35,22 @@ public class ListBlobQueue {
 
   private AzureBlobFileSystemException failureFromProducer;
 
+  /**
+   * Since, Producer just spawns a thread and there are no public method for the
+   * class. Keeping its address in this object will prevent accidental GC close
+   * on the producer object.
+   */
+  private ListBlobProducer producer;
+
   public ListBlobQueue(BlobList initBlobList) {
     if (initBlobList != null) {
       enqueue(initBlobList);
+    }
+  }
+
+  void setProducer(ListBlobProducer producer) {
+    if (this.producer == null) {
+      this.producer = producer;
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -19,13 +19,15 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Queue;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 
 public class ListBlobQueue {
 
-  private final Queue<BlobList> blobLists = new ArrayDeque<>();
+  private final Queue<BlobProperty> blobLists;
 
   private int totalProduced = 0;
 
@@ -42,11 +44,17 @@ public class ListBlobQueue {
    */
   private ListBlobProducer producer;
 
-  public ListBlobQueue() {
+  private final int maxSize;
+  private final int maxConsumedBlobCount;
 
+  public ListBlobQueue(int maxSize, int maxConsumedBlobCount) {
+    blobLists = new ArrayDeque<>(maxSize);
+    this.maxSize = maxSize;
+    this.maxConsumedBlobCount = maxConsumedBlobCount;
   }
 
-  public ListBlobQueue(BlobList initBlobList) {
+  public ListBlobQueue(List<BlobProperty> initBlobList, int maxSize, int maxConsumedBlobCount) {
+    this(maxSize, maxConsumedBlobCount);
     if (initBlobList != null) {
       enqueue(initBlobList);
     }
@@ -74,20 +82,25 @@ public class ListBlobQueue {
     return failureFromProducer;
   }
 
-  public synchronized void enqueue(BlobList blobList) {
-    blobLists.add(blobList);
-    totalProduced += blobList.getBlobPropertyList().size();
+  public void enqueue(List<BlobProperty> blobProperties) {
+    blobLists.addAll(blobProperties);
   }
 
-  public synchronized BlobList dequeue() {
-    BlobList blobList = blobLists.poll();
-    if (blobList != null) {
-      totalConsumed += blobList.getBlobPropertyList().size();
+  public List<BlobProperty> dequeue() {
+    List<BlobProperty> blobProperties = new ArrayList<>();
+    int counter = 0;
+    while(counter < maxConsumedBlobCount && blobLists.size() > 0) {
+      blobProperties.add(blobLists.poll());
+      counter++;
     }
-    return blobList;
+    return blobProperties;
   }
 
-  public synchronized int getConsumerLag() {
-    return totalProduced - totalConsumed;
+  public int size() {
+    return blobLists.size();
+  }
+
+  public int availableSize() {
+    return maxSize - blobLists.size();
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -8,27 +8,23 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemExc
 public class ListBlobQueue {
 
   private final Queue<BlobList> blobLists = new ArrayDeque<>();
+
   private int totalProduced = 0;
+
   private int totalConsumed = 0;
 
-  private Boolean failed = false;
   private Boolean isCompleted = false;
 
   private AzureBlobFileSystemException failureFromProducer;
 
   public ListBlobQueue(BlobList initBlobList) {
-    if(initBlobList != null) {
+    if (initBlobList != null) {
       enqueue(initBlobList);
     }
   }
 
   void setFailed(AzureBlobFileSystemException failure) {
-    failed = true;
     failureFromProducer = failure;
-  }
-
-  Boolean getFailed() {
-    return failed;
   }
 
   public void complete() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -1,0 +1,56 @@
+package org.apache.hadoop.fs.azurebfs.services;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
+
+public class ListBlobQueue {
+
+  private final Queue<BlobList> blobLists = new ArrayDeque<>();
+  private int totalProduced = 0;
+  private int totalConsumed = 0;
+
+  private Boolean failed = false;
+  private Boolean isCompleted = false;
+
+  private AzureBlobFileSystemException failureFromProducer;
+
+  void setFailed(AzureBlobFileSystemException failure) {
+    failed = true;
+    failureFromProducer = failure;
+  }
+
+  Boolean getFailed() {
+    return failed;
+  }
+
+  void complete() {
+    isCompleted = true;
+  }
+
+  Boolean getIsCompleted() {
+    return isCompleted;
+  }
+
+  AzureBlobFileSystemException getException() {
+    return failureFromProducer;
+  }
+
+  public synchronized void enqueue(BlobList blobList) {
+    blobLists.add(blobList);
+    totalProduced += blobList.getBlobPropertyList().size();
+  }
+
+  public synchronized BlobList dequeue() {
+    BlobList blobList = blobLists.poll();
+    if (blobList != null) {
+      totalConsumed += blobList.getBlobPropertyList().size();
+    }
+    return blobList;
+  }
+
+  public synchronized int getConsumerLag() {
+    return totalProduced - totalConsumed;
+  }
+}

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -42,6 +42,10 @@ public class ListBlobQueue {
    */
   private ListBlobProducer producer;
 
+  public ListBlobQueue() {
+
+  }
+
   public ListBlobQueue(BlobList initBlobList) {
     if (initBlobList != null) {
       enqueue(initBlobList);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -59,6 +59,7 @@ public class ListBlobQueue {
   }
 
   /**
+   * @param initBlobList list of blobProperties to be enqueued in th queue
    * @param maxSize maxSize of the queue.
    * @param maxConsumedBlobCount maximum number of blobs that would be returned
    * by {@link #dequeue()} method.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -26,7 +26,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -51,7 +50,7 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 /**
  * For a directory enabled for atomic-rename, before rename starts, a
  * file with -RenamePending.json suffix is created. In this file, the states required
- * for the rename are given. This file is created by {@link #preRename(List, Boolean)} ()} method.
+ * for the rename are given. This file is created by {@link #preRename(Boolean)} ()} method.
  * This is important in case the JVM process crashes during rename, the atomicity
  * will be maintained, when the job calls {@link AzureBlobFileSystem#listStatus(Path)}
  * or {@link AzureBlobFileSystem#getFileStatus(Path)}. On these API calls to filesystem,
@@ -198,13 +197,12 @@ public class RenameAtomicityUtils {
    * } }</pre>
    * @throws IOException Thrown when fail to write file.
    */
-  public void preRename(List<BlobProperty> blobPropertyList,
-      final Boolean isCreateOperationOnBlobEndpoint) throws IOException {
+  public void preRename(final Boolean isCreateOperationOnBlobEndpoint) throws IOException {
     Path path = getRenamePendingFilePath();
     LOG.debug("Preparing to write atomic rename state to {}", path.toString());
     OutputStream output = null;
 
-    String contents = makeRenamePendingFileContents(blobPropertyList);
+    String contents = makeRenamePendingFileContents();
 
     // Write file.
     try {
@@ -263,7 +261,7 @@ public class RenameAtomicityUtils {
    *
    * @return JSON string which represents the operation.
    */
-  private String makeRenamePendingFileContents(List<BlobProperty> blobPropertyList) {
+  private String makeRenamePendingFileContents() {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
     String time = sdf.format(new Date());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -25,7 +25,6 @@ import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -49,12 +48,10 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationExcep
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
-import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.FORWARD_SLASH;
-
 /**
  * For a directory enabled for atomic-rename, before rename starts, a
  * file with -RenamePending.json suffix is created. In this file, the states required
- * for the rename are given. This file is created by {@link #writeFile()} method.
+ * for the rename are given. This file is created by {@link #preRename(List, Boolean)} ()} method.
  * This is important in case the JVM process crashes during rename, the atomicity
  * will be maintained, when the job calls {@link AzureBlobFileSystem#listStatus(Path)}
  * or {@link AzureBlobFileSystem#getFileStatus(Path)}. On these API calls to filesystem,
@@ -97,8 +94,7 @@ public class RenameAtomicityUtils {
     final RenamePendingFileInfo renamePendingFileInfo = readFile(path);
     if (renamePendingFileInfo != null) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
-          renamePendingFileInfo.srcList,
-          renamePendingFileInfo.destinationSuffix);
+          renamePendingFileInfo.src);
     }
   }
 
@@ -159,16 +155,7 @@ public class RenameAtomicityUtils {
         newFolderName.textValue())) {
       RenamePendingFileInfo renamePendingFileInfo = new RenamePendingFileInfo();
       renamePendingFileInfo.destination = new Path(newFolderName.textValue());
-      String srcDir = oldFolderName.textValue() + FORWARD_SLASH;
-      List<Path> srcPaths = new ArrayList<>();
-      List<String> destinationSuffix = new ArrayList<>();
-      JsonNode fileList = json.get("FileList");
-      for (int i = 0; i < fileList.size(); i++) {
-        destinationSuffix.add(fileList.get(i).textValue());
-        srcPaths.add(new Path(srcDir + fileList.get(i).textValue()));
-      }
-      renamePendingFileInfo.srcList = srcPaths;
-      renamePendingFileInfo.destinationSuffix = destinationSuffix;
+      renamePendingFileInfo.src = new Path(oldFolderName.textValue());
       return renamePendingFileInfo;
     }
     return null;
@@ -192,15 +179,14 @@ public class RenameAtomicityUtils {
   /**
    * Write to disk the information needed to redo folder rename,
    * in JSON format. The file name will be
-   * {@code wasb://<sourceFolderPrefix>/folderName-RenamePending.json}
+   * {@code abfs://<sourceFolderPrefix>/folderName-RenamePending.json}
    * The file format will be:
    * <pre>{@code
    * {
    *   FormatVersion: "1.0",
    *   OperationTime: "<YYYY-MM-DD HH:MM:SS.MMM>",
    *   OldFolderName: "<key>",
-   *   NewFolderName: "<key>",
-   *   FileList: [ <string> , <string> , ... ]
+   *   NewFolderName: "<key>"
    * }
    *
    * Here's a sample:
@@ -208,11 +194,7 @@ public class RenameAtomicityUtils {
    *  FormatVersion: "1.0",
    *  OperationUTCTime: "2014-07-01 23:50:35.572",
    *  OldFolderName: "user/ehans/folderToRename",
-   *  NewFolderName: "user/ehans/renamedFolder",
-   *  FileList: [
-   *    "innerFile",
-   *    "innerFile2"
-   *  ]
+   *  NewFolderName: "user/ehans/renamedFolder"
    * } }</pre>
    * @throws IOException Thrown when fail to write file.
    */
@@ -286,58 +268,13 @@ public class RenameAtomicityUtils {
     sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
     String time = sdf.format(new Date());
 
-    // Make file list string
-    StringBuilder builder = new StringBuilder();
-    builder.append("[\n");
-    for (int i = 0; i != blobPropertyList.size(); i++) {
-      if (i > 0) {
-        builder.append(",\n");
-      }
-      builder.append("    ");
-      final String noPrefix;
-      /*
-       * The marker file for the source directory has the same path on non-HNS.
-       * For the other files, the fileList has to save the filePath relative to the
-       * source directory.
-       */
-      if (!blobPropertyList.get(i)
-          .getPath()
-          .toUri()
-          .getPath()
-          .equals(srcPath.toUri().getPath())) {
-        noPrefix = StringUtils.removeStart(
-            blobPropertyList.get(i).getPath().toUri().getPath(),
-            srcPath.toUri().getPath() + FORWARD_SLASH);
-      } else {
-        noPrefix = "";
-      }
-
-      // Quote string file names, escaping any possible " characters or other
-      // necessary characters in the name.
-      builder.append(quote(noPrefix));
-      if (builder.length() >=
-          MAX_RENAME_PENDING_FILE_SIZE - FORMATTING_BUFFER) {
-
-        // Give up now to avoid using too much memory.
-        LOG.error(
-            "Internal error: Exceeded maximum rename pending file size of {} bytes.",
-            MAX_RENAME_PENDING_FILE_SIZE);
-
-        // return some bad JSON with an error message to make it human readable
-        return "exceeded maximum rename pending file size";
-      }
-    }
-    builder.append("\n  ]");
-    String fileList = builder.toString();
-
     // Make file contents as a string. Again, quote file names, escaping
     // characters as appropriate.
     String contents = "{\n"
         + "  FormatVersion: \"1.0\",\n"
         + "  OperationUTCTime: \"" + time + "\",\n"
         + "  OldFolderName: " + quote(srcPath.toUri().getPath()) + ",\n"
-        + "  NewFolderName: " + quote(dstPath.toUri().getPath()) + ",\n"
-        + "  FileList: " + fileList + "\n"
+        + "  NewFolderName: " + quote(dstPath.toUri().getPath()) + "\n"
         + "}\n";
 
     return contents;
@@ -430,16 +367,11 @@ public class RenameAtomicityUtils {
 
   private static class RenamePendingFileInfo {
     public Path destination;
-    public List<Path> srcList;
-    /**
-     * Relative paths from the destination path.
-     */
-    public List<String> destinationSuffix;
+    public Path src;
   }
 
   public static interface RedoRenameInvocation {
-    void redo(Path destination, List<Path> sourcePaths,
-        final List<String> destinationSuffix) throws
+    void redo(Path destination, Path src) throws
         AzureBlobFileSystemException;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
@@ -35,8 +34,7 @@ public class RenameNonAtomicUtils extends RenameAtomicityUtils {
   }
 
   @Override
-  public void preRename(final List<BlobProperty> blobPropertyList,
-      final Boolean isCreateOperationOnBlobEndpoint)
+  public void preRename(final Boolean isCreateOperationOnBlobEndpoint)
       throws IOException {
 
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
@@ -602,7 +602,7 @@ public class ITestAzureBlobFileSystemBlobConfig
       isRenameOverBlobEndpoint[0] = true;
       return answer.callRealMethod();
     }).when(client).copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
-        null, Mockito.any(TracingContext.class));
+        Mockito.nullable(String.class), Mockito.any(TracingContext.class));
   }
 
   private void countDeleteOverAbfsAndWasb(final NativeAzureFileSystem nativeAzureFileSystem,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
@@ -601,7 +601,8 @@ public class ITestAzureBlobFileSystemBlobConfig
     Mockito.doAnswer(answer -> {
       isRenameOverBlobEndpoint[0] = true;
       return answer.callRealMethod();
-    }).when(client).copyBlob(Mockito.any(Path.class), Mockito.any(Path.class), Mockito.any(TracingContext.class));
+    }).when(client).copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
+        null, Mockito.any(TracingContext.class));
   }
 
   private void countDeleteOverAbfsAndWasb(final NativeAzureFileSystem nativeAzureFileSystem,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.fs.azurebfs.services.OperativeEndpoint;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.test.LambdaTestUtils;
 
-
 import org.junit.Assert;
 import org.junit.Assume;
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -932,7 +932,9 @@ public class ITestAzureBlobFileSystemCreate extends
   @Test
   public void testCreateNonRecursiveForAtomicDirectoryFile() throws Exception {
     AzureBlobFileSystem fileSystem = getFileSystem();
-    Assume.assumeTrue(fileSystem.getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB);
+    Assume.assumeTrue(
+        fileSystem.getAbfsStore().getAbfsConfiguration().getPrefixMode()
+            == PrefixMode.BLOB);
     fileSystem.setWorkingDirectory(new Path("/"));
     fileSystem.mkdirs(new Path("/hbase/dir"));
     fileSystem.createFile(new Path("/hbase/dir/file"))
@@ -946,10 +948,12 @@ public class ITestAzureBlobFileSystemCreate extends
 
   @Test
   public void testActiveCreateNonRecursiveDenyParallelReadOnAtomicDir() throws Exception {
+    Assume.assumeTrue(
+        getFileSystem().getAbfsStore().getAbfsConfiguration().getPrefixMode()
+            == PrefixMode.BLOB);
     AzureBlobFileSystem fileSystem = (AzureBlobFileSystem) FileSystem.newInstance(getRawConfiguration());
     AbfsClient client = Mockito.spy(fileSystem.getAbfsClient());
     fileSystem.getAbfsStore().setClient(client);
-    Assume.assumeTrue(fileSystem.getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.BLOB);
     fileSystem.setWorkingDirectory(new Path("/"));
     fileSystem.mkdirs(new Path("/hbase/dir"));
     fileSystem.create(new Path("/hbase/dir/file"));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -952,9 +952,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
   @Test
   public void testActiveCreateNonRecursiveDenyParallelReadOnAtomicDir() throws Exception {
-    Assume.assumeTrue(
-        getFileSystem().getAbfsStore().getAbfsConfiguration().getPrefixMode()
-            == PrefixMode.BLOB);
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
     Configuration configuration = Mockito.spy(getRawConfiguration());
     configuration.set(FS_AZURE_LEASE_CREATE_NON_RECURSIVE, "true");
     AzureBlobFileSystem fileSystem = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
@@ -999,9 +997,7 @@ public class ITestAzureBlobFileSystemCreate extends
 
   @Test
   public void testActiveCreateNonRecursiveNotDenyParallelReadOnAtomicDirIfLeaseConfigDisabled() throws Exception {
-    Assume.assumeTrue(
-        getFileSystem().getAbfsStore().getAbfsConfiguration().getPrefixMode()
-            == PrefixMode.BLOB);
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
     Configuration configuration = Mockito.spy(getRawConfiguration());
     AzureBlobFileSystem fileSystem = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     AbfsClient client = Mockito.spy(fileSystem.getAbfsClient());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -996,7 +996,7 @@ public class ITestAzureBlobFileSystemCreate extends
   }
 
   @Test
-  public void testActiveCreateNonRecursiveNotDenyParallelReadOnAtomicDirIfLeaseConfigDisabled() throws Exception {
+  public void testActiveCreateNonRecursiveNotDenyParallelRenameOnAtomicDirIfLeaseConfigDisabled() throws Exception {
     Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
     Configuration configuration = Mockito.spy(getRawConfiguration());
     AzureBlobFileSystem fileSystem = (AzureBlobFileSystem) FileSystem.newInstance(configuration);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
@@ -141,7 +141,7 @@ public class ITestAzureBlobFileSystemDelegationSASForBlobEndpoint
       Mockito.doReturn(httpOp).when(op).getResult();
       return op;
     }).when(spiedClient).copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
-        Mockito.any(TracingContext.class));
+        null, Mockito.any(TracingContext.class));
     fileSystem.create(new Path("/test1/file"));
     fileSystem.rename(new Path("/test1/file"), new Path("/test1/file2"));
     Assert.assertTrue(fileSystem.exists(new Path("/test1/file2")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
@@ -141,7 +141,7 @@ public class ITestAzureBlobFileSystemDelegationSASForBlobEndpoint
       Mockito.doReturn(httpOp).when(op).getResult();
       return op;
     }).when(spiedClient).copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
-        null, Mockito.any(TracingContext.class));
+        Mockito.nullable(String.class), Mockito.any(TracingContext.class));
     fileSystem.create(new Path("/test1/file"));
     fileSystem.rename(new Path("/test1/file"), new Path("/test1/file2"));
     Assert.assertTrue(fileSystem.exists(new Path("/test1/file2")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
@@ -24,7 +24,6 @@ import java.net.HttpURLConnection;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.fs.Path;
@@ -897,7 +896,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
       throws AzureBlobFileSystemException {
     try {
       fs.getAbfsClient()
-          .deleteBlobPath(srcParent, Mockito.mock(TracingContext.class));
+          .deleteBlobPath(srcParent, null, Mockito.mock(TracingContext.class));
     } catch (AbfsRestOperationException ex) {
       if(ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
         throw ex;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
@@ -348,7 +348,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
     tracingContext.setListener(listener);
 
     AbfsLease lease = new AbfsLease(fs.getAbfsClient(),
-        testFilePath.toUri().getPath(), tracingContext);
+        testFilePath.toUri().getPath(), null, tracingContext);
     Assert.assertNotNull("Did not successfully lease file", lease.getLeaseID());
     listener.setOperation(FSOperationType.RELEASE_LEASE);
     lease.free();
@@ -362,7 +362,8 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .doCallRealMethod().when(mockClient)
         .acquireLease(anyString(), anyInt(), any(TracingContext.class));
 
-    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, tracingContext);
+    lease = new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
+        tracingContext);
     Assert.assertNotNull("Acquire lease should have retried", lease.getLeaseID());
     lease.free();
     Assert.assertEquals("Unexpected acquire retry count", 2, lease.getAcquireRetryCount());
@@ -371,7 +372,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .acquireLease(anyString(), anyInt(), any(TracingContext.class));
 
     LambdaTestUtils.intercept(AzureBlobFileSystemException.class, () -> {
-      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1,
+      new AbfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
           tracingContext);
     });
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
@@ -350,7 +350,7 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
     tracingContext.setListener(listener);
 
     AbfsLease lease;
-    if(getPrefixMode(fs) == PrefixMode.BLOB) {
+    if (getPrefixMode(fs) == PrefixMode.BLOB) {
       lease = new AbfsBlobLease(fs.getAbfsClient(),
           testFilePath.toUri().getPath(), null, tracingContext);
     } else {
@@ -375,11 +375,13 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .doCallRealMethod().when(mockClient)
         .acquireBlobLease(anyString(), anyInt(), any(TracingContext.class));
 
-    if(getPrefixMode(fs) == PrefixMode.BLOB) {
-      lease = new AbfsBlobLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
+    if (getPrefixMode(fs) == PrefixMode.BLOB) {
+      lease = new AbfsBlobLease(mockClient, testFilePath.toUri().getPath(), 5,
+          1, null,
           tracingContext);
     } else {
-      lease = new AbfsDfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
+      lease = new AbfsDfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1,
+          null,
           tracingContext);
     }
     Assert.assertNotNull("Acquire lease should have retried", lease.getLeaseID());
@@ -393,8 +395,9 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .acquireBlobLease(anyString(), anyInt(), any(TracingContext.class));
 
     LambdaTestUtils.intercept(AzureBlobFileSystemException.class, () -> {
-      if(getPrefixMode(fs) == PrefixMode.BLOB) {
-        new AbfsBlobLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
+      if (getPrefixMode(fs) == PrefixMode.BLOB) {
+        new AbfsBlobLease(mockClient, testFilePath.toUri().getPath(), 5, 1,
+            null,
             tracingContext);
       } else {
         new AbfsDfsLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemLease.java
@@ -370,6 +370,11 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
         .doCallRealMethod().when(mockClient)
         .acquireLease(anyString(), anyInt(), any(TracingContext.class));
 
+    doThrow(new AbfsLease.LeaseException("failed to acquire 1"))
+        .doThrow(new AbfsLease.LeaseException("failed to acquire 2"))
+        .doCallRealMethod().when(mockClient)
+        .acquireBlobLease(anyString(), anyInt(), any(TracingContext.class));
+
     if(getPrefixMode(fs) == PrefixMode.BLOB) {
       lease = new AbfsBlobLease(mockClient, testFilePath.toUri().getPath(), 5, 1, null,
           tracingContext);
@@ -383,6 +388,9 @@ public class ITestAzureBlobFileSystemLease extends AbstractAbfsIntegrationTest {
 
     doThrow(new AbfsLease.LeaseException("failed to acquire")).when(mockClient)
         .acquireLease(anyString(), anyInt(), any(TracingContext.class));
+
+    doThrow(new AbfsLease.LeaseException("failed to acquire")).when(mockClient)
+        .acquireBlobLease(anyString(), anyInt(), any(TracingContext.class));
 
     LambdaTestUtils.intercept(AzureBlobFileSystemException.class, () -> {
       if(getPrefixMode(fs) == PrefixMode.BLOB) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1733,6 +1733,7 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testParallelBlobLeaseOnChildBlobInRenameSrcDir()
       throws Exception {
+    assumeNonHnsAccountBlobEndpoint(getFileSystem());
     AzureBlobFileSystem fs = Mockito.spy(
         (AzureBlobFileSystem) FileSystem.newInstance(getRawConfiguration()));
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -165,7 +165,6 @@ public class ITestAzureBlobFileSystemRename extends
     assertPathDoesNotExist(fs, "rename source dir", test1);
   }
 
-  @Ignore
   @Test
   public void testRenameFirstLevelDirectory() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
@@ -1363,7 +1362,6 @@ public class ITestAzureBlobFileSystemRename extends
     Assert.assertTrue(connectionResetThrown[0]);
   }
 
-  @Ignore
   @Test
   public void testRenameLargeNestedDir() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -445,7 +446,9 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           TracingContext tracingContext = answer.getArgument(1);
           Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath()));
+              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
+                  || "/hbase/test1/test2/test3".equalsIgnoreCase(
+                  path.toUri().getPath()));
           deletedCount.incrementAndGet();
           client.deleteBlobPath(path, tracingContext);
           return null;
@@ -456,7 +459,7 @@ public class ITestAzureBlobFileSystemRename extends
 
     spiedFsForListPath.listStatus(new Path("hbase/test1/test2"));
     Assert.assertTrue(openRequiredFile[0] == 1);
-    Assert.assertTrue(deletedCount.get() == 2);
+    Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(
         failedCopyPath.replace("test1/test2/test3/", "test4/test3/"))));
@@ -553,7 +556,8 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           TracingContext tracingContext = answer.getArgument(1);
           Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath()));
+              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
+                  || "/hbase/test1/test2".equalsIgnoreCase(path.toUri().getPath()));
           deletedCount.incrementAndGet();
           client.deleteBlobPath(path, tracingContext);
           return null;
@@ -569,7 +573,7 @@ public class ITestAzureBlobFileSystemRename extends
     final FileStatus[] listFileResult = spiedFsForListPath.listStatus(
         new Path("hbase/test1"));
     Assert.assertTrue(openRequiredFile[0] == 1);
-    Assert.assertTrue(deletedCount.get() == 2);
+    Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(
         failedCopyPath.replace("test1/test2/test3/", "test4/test2/test3/"))));
@@ -668,7 +672,7 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           TracingContext tracingContext = answer.getArgument(1);
           Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath()));
+              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath()) || "/hbase/test1/test2".equalsIgnoreCase(path.toUri().getPath()));
           deletedCount.incrementAndGet();
           client.deleteBlobPath(path, tracingContext);
           return null;
@@ -695,7 +699,7 @@ public class ITestAzureBlobFileSystemRename extends
     Assert.assertTrue(notFoundExceptionReceived);
     Assert.assertNull(fileStatus);
     Assert.assertTrue(openRequiredFile[0] == 1);
-    Assert.assertTrue(deletedCount.get() == 2);
+    Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(
         failedCopyPath.replace("test1/test2/test3/", "test4/test2/test3/"))));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1922,4 +1922,20 @@ public class ITestAzureBlobFileSystemRename extends
     Assertions.assertThat(fs.exists(new Path("/testDir1/file1"))).isTrue();
     Assertions.assertThat(fs.exists(new Path("/testDir1/file2"))).isTrue();
   }
+
+  @Test
+  public void testBlobAtomicRenameSrcAndDstAreNotLeftLeased() throws Exception {
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    assumeNonHnsAccountBlobEndpoint(fs);
+    fs.setWorkingDirectory(new Path("/"));
+    fs.create(new Path("/hbase/dir1/blob1"));
+    fs.create(new Path("/hbase/dir1/blob2"));
+    fs.rename(new Path("/hbase/dir1/"), new Path("/hbase/dir2"));
+    fs.create(new Path("/hbase/dir1/blob1"));
+    byte[] bytes = new byte[4 * ONE_MB];
+    new Random().nextBytes(bytes);
+    try (FSDataOutputStream os = fs.append(new Path("hbase/dir2/blob1"))) {
+      os.write(bytes);
+    }
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperationTestUtil;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_LEASE_CREATE_NON_RECURSIVE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_REDIRECT_RENAME;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TRUE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_FALLBACK_TO_DFS;
@@ -1735,8 +1736,10 @@ public class ITestAzureBlobFileSystemRename extends
   @Test
   public void testParallelCreateNonRecursiveToFilePartOfAtomicDirectoryInRename()
       throws Exception {
-    FileSystem fsCreate = FileSystem.newInstance(getRawConfiguration());
-    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(getRawConfiguration());
+    Configuration configuration = Mockito.spy(getRawConfiguration());
+    configuration.set(FS_AZURE_LEASE_CREATE_NON_RECURSIVE, "true");
+    FileSystem fsCreate = FileSystem.newInstance(configuration);
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     assumeNonHnsAccountBlobEndpoint(fs);
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(new Path("/hbase/dir1"));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1796,7 +1796,8 @@ public class ITestAzureBlobFileSystemRename extends
   }
 
   @Test
-  public void testBlobRenameOfDirectoryHavingNeighborWithSamePrefix() throws Exception {
+  public void testBlobRenameOfDirectoryHavingNeighborWithSamePrefix()
+      throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     assumeNonHnsAccountBlobEndpoint(fs);
     fs.mkdirs(new Path("/testDir/dir"));
@@ -1820,8 +1821,11 @@ public class ITestAzureBlobFileSystemRename extends
   }
 
   @Test
-  public void testBlobRenameCancelRenewTimerForLeaseTakenInAtomicRename() throws Exception {
-    AzureBlobFileSystem fs = Mockito.spy((AzureBlobFileSystem) FileSystem.newInstance(getRawConfiguration()));
+  public void testBlobRenameCancelRenewTimerForLeaseTakenInAtomicRename()
+      throws Exception {
+    AzureBlobFileSystem fs = Mockito.spy(
+        (AzureBlobFileSystem) FileSystem.newInstance(getRawConfiguration()));
+    assumeNonHnsAccountBlobEndpoint(fs);
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     Mockito.doReturn(store).when(fs).getAbfsStore();
 
@@ -1831,15 +1835,19 @@ public class ITestAzureBlobFileSystemRename extends
 
     final List<AbfsBlobLease> leases = new ArrayList<>();
     Mockito.doAnswer(answer -> {
-      AbfsBlobLease lease = Mockito.spy((AbfsBlobLease) answer.callRealMethod());
-      leases.add(lease);
-      return lease;
-    }).when(store).getBlobLease(Mockito.anyString(), Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
+          AbfsBlobLease lease = Mockito.spy(
+              (AbfsBlobLease) answer.callRealMethod());
+          leases.add(lease);
+          return lease;
+        })
+        .when(store)
+        .getBlobLease(Mockito.anyString(), Mockito.nullable(Integer.class),
+            Mockito.any(TracingContext.class));
 
     fs.rename(new Path("/hbase/dir"), new Path("/hbase/dir2"));
 
     Assertions.assertThat(leases).hasSize(3);
-    for(AbfsBlobLease lease : leases) {
+    for (AbfsBlobLease lease : leases) {
       Mockito.verify(lease, Mockito.times(1)).cancelTimer();
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1008,18 +1008,9 @@ public class ITestAzureBlobFileSystemRename extends
       return op;
     }).when(spiedClient).acquireBlobLease(Mockito.anyString(), Mockito.anyInt(), Mockito.any(TracingContext.class));
     Mockito.doAnswer(answer -> {
-          final Path srcPath = answer.getArgument(0);
-          final Path dstPath = answer.getArgument(1);
-          final String leaseId = answer.getArgument(2);
-          final TracingContext tracingContext = answer.getArgument(3);
-
-
-            throw new AbfsRestOperationException(HttpURLConnection.HTTP_UNAVAILABLE,
-                AzureServiceErrorCode.INGRESS_OVER_ACCOUNT_LIMIT.getErrorCode(),
-                "Ingress is over the account limit.", new Exception());
-
-//          fs.getAbfsStore().copyBlob(srcPath, dstPath, leaseId, tracingContext);
-//          return null;
+          throw new AbfsRestOperationException(HttpURLConnection.HTTP_UNAVAILABLE,
+              AzureServiceErrorCode.INGRESS_OVER_ACCOUNT_LIMIT.getErrorCode(),
+              "Ingress is over the account limit.", new Exception());
         })
         .when(spiedAbfsStore)
         .copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
@@ -1028,8 +1019,6 @@ public class ITestAzureBlobFileSystemRename extends
       spiedFs.rename(new Path(srcDir),
           new Path("hbase/test4"));
     } catch (Exception ex) {
-      int a = 1;
-      a++;
     }
 
     Assert.assertFalse(spiedFs.exists(
@@ -1582,9 +1571,7 @@ public class ITestAzureBlobFileSystemRename extends
     fileSystem.create(new Path(srcFile));
 
 
-    intercept(FileNotFoundException.class, () -> {
-      fileSystem.rename(new Path(srcFile), new Path(dstFile));
-    });
+    Assert.assertFalse(fileSystem.rename(new Path(srcFile), new Path(dstFile)));
     Assert.assertFalse(fileSystem.exists(new Path(dstFile)));
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -36,6 +36,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Ignore;
@@ -1792,4 +1794,27 @@ public class ITestAzureBlobFileSystemRename extends
     Assert.assertTrue(exceptionCaught.get());
   }
 
+  @Test
+  public void testBlobRenameOfDirectoryHavingNeighborWithSamePrefix() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    assumeNonHnsAccountBlobEndpoint(fs);
+    fs.mkdirs(new Path("/testDir/dir"));
+    fs.mkdirs(new Path("/testDir/dirSamePrefix"));
+    fs.create(new Path("/testDir/dir/file1"));
+    fs.create(new Path("/testDir/dir/file2"));
+
+    fs.create(new Path("/testDir/dirSamePrefix/file1"));
+    fs.create(new Path("/testDir/dirSamePrefix/file2"));
+
+    fs.rename(new Path("/testDir/dir"), new Path("/testDir/dir2"));
+
+    Assertions.assertThat(fs.exists(new Path("/testDir/dirSamePrefix/file1")))
+        .isTrue();
+    Assertions.assertThat(fs.exists(new Path("/testDir/dir/file1")))
+        .isFalse();
+    Assertions.assertThat(fs.exists(new Path("/testDir/dir/file2")))
+        .isFalse();
+    Assertions.assertThat(fs.exists(new Path("/testDir/dir/")))
+        .isFalse();
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -990,6 +990,7 @@ public class ITestAzureBlobFileSystemRename extends
     String srcDir = "/hbase/test1/test2/test3";
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(new Path(srcDir));
+    fs.create(new Path(srcDir, "file1"));
     fs.mkdirs(new Path("hbase/test4"));
 
     AzureBlobFileSystem spiedFs = Mockito.spy(fs);
@@ -1012,13 +1013,13 @@ public class ITestAzureBlobFileSystemRename extends
           final String leaseId = answer.getArgument(2);
           final TracingContext tracingContext = answer.getArgument(3);
 
-          if (srcDir.equalsIgnoreCase(srcPath.toUri().getPath())) {
+
             throw new AbfsRestOperationException(HttpURLConnection.HTTP_UNAVAILABLE,
                 AzureServiceErrorCode.INGRESS_OVER_ACCOUNT_LIMIT.getErrorCode(),
                 "Ingress is over the account limit.", new Exception());
-          }
-          fs.getAbfsStore().copyBlob(srcPath, dstPath, leaseId, tracingContext);
-          return null;
+
+//          fs.getAbfsStore().copyBlob(srcPath, dstPath, leaseId, tracingContext);
+//          return null;
         })
         .when(spiedAbfsStore)
         .copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
@@ -1027,7 +1028,8 @@ public class ITestAzureBlobFileSystemRename extends
       spiedFs.rename(new Path(srcDir),
           new Path("hbase/test4"));
     } catch (Exception ex) {
-
+      int a = 1;
+      a++;
     }
 
     Assert.assertFalse(spiedFs.exists(
@@ -1035,7 +1037,11 @@ public class ITestAzureBlobFileSystemRename extends
 
     //call listPath API, it will recover the rename atomicity.
     for(Map.Entry<String, String> entry : pathLeaseIdMap.entrySet()) {
-      fs.getAbfsClient().releaseBlobLease(entry.getKey(), entry.getValue(), Mockito.mock(TracingContext.class));
+      try {
+        fs.getAbfsClient()
+            .releaseBlobLease(entry.getKey(), entry.getValue(),
+                Mockito.mock(TracingContext.class));
+      } catch (Exception e) {}
     }
 
     final AzureBlobFileSystem spiedFsForListPath = Mockito.spy(fs);
@@ -1075,7 +1081,7 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           String leaseId = answer.getArgument(1);
           TracingContext tracingContext = answer.getArgument(2);
-          Assert.assertTrue((srcDir).equalsIgnoreCase(path.toUri().getPath()));
+          Assert.assertTrue(((srcDir).equalsIgnoreCase(path.toUri().getPath()) || (srcDir+"/file1").equalsIgnoreCase(path.toUri().getPath())));
           deletedCount.incrementAndGet();
           client.deleteBlobPath(path, leaseId, tracingContext);
           return null;
@@ -1101,7 +1107,7 @@ public class ITestAzureBlobFileSystemRename extends
     Assert.assertTrue(notFoundExceptionReceived);
     Assert.assertNull(fileStatus);
     Assert.assertTrue(openRequiredFile[0] == 1);
-    Assert.assertTrue(deletedCount.get() == 2);
+    Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(srcDir)));
     Assert.assertTrue(spiedFsForListPath.getFileStatus(
             new Path(srcDir.replace("test1/test2/test3", "test4/test3/")))

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -1,4 +1,78 @@
 package org.apache.hadoop.fs.azurebfs;
 
-public class ITestListBlobProducer {
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
+import org.apache.hadoop.fs.azurebfs.services.ListBlobConsumer;
+import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
+import org.apache.hadoop.fs.azurebfs.services.ListBlobQueue;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_MAX_CONSUMER_LAG;
+
+public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
+
+  public ITestListBlobProducer() throws Exception {
+    super();
+  }
+
+  @Test
+  public void testProducerWaitingForConsumerLagToGoDown() throws Exception {
+    Configuration configuration = Mockito.spy(getRawConfiguration());
+    configuration.set(FS_AZURE_MAX_CONSUMER_LAG, "10");
+    AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
+        configuration);
+    AbfsClient client = fs.getAbfsClient();
+    AbfsClient spiedClient = Mockito.spy(client);
+    fs.getAbfsStore().setClient(spiedClient);
+    fs.setWorkingDirectory(new Path("/"));
+    fs.mkdirs(new Path("/src"));
+    for (int i = 0; i < 20; i++) {
+      fs.create(new Path("/src/file" + i));
+    }
+    AtomicBoolean produced = new AtomicBoolean(true);
+
+    AtomicInteger producedBlobs = new AtomicInteger(0);
+    Mockito.doAnswer(answer -> {
+          AbfsRestOperation op = client.getListBlobs(answer.getArgument(0),
+              answer.getArgument(1), 1, answer.getArgument(3));
+          producedBlobs.incrementAndGet();
+          produced.set(true);
+          return op;
+        })
+        .when(spiedClient)
+        .getListBlobs(Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.nullable(Integer.class),
+            Mockito.nullable(TracingContext.class));
+
+    ListBlobQueue queue = new ListBlobQueue(null);
+    ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
+        null, Mockito.mock(
+        TracingContext.class));
+    ListBlobConsumer consumer = new ListBlobConsumer(queue);
+    while (producedBlobs.get() < 10) ;
+
+    int producedBlobCount = producedBlobs.get();
+
+    while (!consumer.isCompleted()) {
+      produced.set(false);
+      consumer.consume();
+      while (!produced.get() && !queue.getIsCompleted()) ;
+      if (!queue.getIsCompleted()) {
+        Assert.assertEquals(producedBlobs.get() - 1, producedBlobCount);
+      }
+      producedBlobCount = producedBlobs.get();
+    }
+
+    Assert.assertTrue(producedBlobCount == 20);
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -36,6 +37,7 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobConsumer;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobQueue;
+import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_MAX_CONSUMER_LAG;
@@ -44,6 +46,14 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
 
   public ITestListBlobProducer() throws Exception {
     super();
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    Assume.assumeTrue(
+        getFileSystem().getAbfsStore().getAbfsConfiguration().getPrefixMode()
+            == PrefixMode.BLOB);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -100,7 +100,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
       synchronized (testObj) {
         listBlobInvoked.incrementAndGet();
         AbfsRestOperation op = client.getListBlobs(answer.getArgument(0),
-            answer.getArgument(1), 1, answer.getArgument(3));
+            answer.getArgument(1), answer.getArgument(2), 1, answer.getArgument(4));
         producedBlobs.incrementAndGet();
         latch.countDown();
         if(producedBlobs.get() > 10) {
@@ -111,7 +111,8 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
         })
         .when(spiedClient)
         .getListBlobs(Mockito.nullable(String.class),
-            Mockito.nullable(String.class), Mockito.nullable(Integer.class),
+            Mockito.nullable(String.class), Mockito.nullable(String.class),
+            Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
 
@@ -156,7 +157,8 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
         })
         .when(spiedClient)
         .getListBlobs(Mockito.nullable(String.class),
-            Mockito.nullable(String.class), Mockito.nullable(Integer.class),
+            Mockito.nullable(String.class), Mockito.nullable(String.class),
+            Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
     ListBlobQueue queue = new ListBlobQueue(getConfiguration().getProducerQueueMaxSize(),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -19,6 +19,12 @@
 package org.apache.hadoop.fs.azurebfs;
 
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -34,6 +40,7 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationExcep
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
+import org.apache.hadoop.fs.azurebfs.services.BlobProperty;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobConsumer;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobQueue;
@@ -67,53 +74,61 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
     fs.getAbfsStore().setClient(spiedClient);
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(new Path("/src"));
+    ExecutorService executor = Executors.newFixedThreadPool(5);
+    List<Future> futureList = new ArrayList<>();
     for (int i = 0; i < 20; i++) {
-      fs.create(new Path("/src/file" + i));
+      int iter = i;
+      futureList.add(executor.submit(() -> {
+        return fs.create(new Path("/src/file" + iter));
+      }));
     }
-    AtomicBoolean produced = new AtomicBoolean(true);
+    for(Future future : futureList) {
+      future.get();
+    }
 
     AtomicInteger producedBlobs = new AtomicInteger(0);
     AtomicInteger listBlobInvoked = new AtomicInteger(0);
 
+    final ITestListBlobProducer testObj = this;
+    final ListBlobQueue queue = new ListBlobQueue(
+        fs.getAbfsStore().getAbfsConfiguration().getProducerQueueMaxSize(),
+        1);
+
     Mockito.doAnswer(answer -> {
-          listBlobInvoked.incrementAndGet();
-          AbfsRestOperation op = client.getListBlobs(answer.getArgument(0),
-              answer.getArgument(1), 1, answer.getArgument(3));
-          producedBlobs.incrementAndGet();
-          produced.set(true);
-          return op;
+      synchronized (testObj) {
+        listBlobInvoked.incrementAndGet();
+        AbfsRestOperation op = client.getListBlobs(answer.getArgument(0),
+            answer.getArgument(1), 1, answer.getArgument(3));
+        producedBlobs.incrementAndGet();
+        if(producedBlobs.get() > 10) {
+          Assert.assertTrue(queue.availableSize() > 0);
+        }
+        return op;
+      }
         })
         .when(spiedClient)
         .getListBlobs(Mockito.nullable(String.class),
             Mockito.nullable(String.class), Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
-    ListBlobQueue queue = new ListBlobQueue(
-        getConfiguration().getProducerQueueMaxSize(),
-        getConfiguration().getBlobDirRenameMaxThread());
+
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
         null, Mockito.mock(
         TracingContext.class));
     ListBlobConsumer consumer = new ListBlobConsumer(queue);
     while (producedBlobs.get() < 10) ;
 
-    int producedBlobCount = producedBlobs.get();
-
     int oldInvocation = listBlobInvoked.get();
-    Thread.sleep(10_000L);
     Assert.assertTrue(listBlobInvoked.get() == oldInvocation);
 
     while (!consumer.isCompleted()) {
-      produced.set(false);
-      consumer.consume();
-      while (!produced.get() && !queue.getIsCompleted()) ;
-      if (!queue.getIsCompleted()) {
-        Assert.assertEquals(producedBlobs.get() - 1, producedBlobCount);
+      synchronized (testObj) {
+        consumer.consume();
+        Assert.assertTrue(queue.availableSize() > 0);
       }
-      producedBlobCount = producedBlobs.get();
     }
 
-    Assert.assertTrue(producedBlobCount == 20);
+    Assert.assertTrue(producedBlobs.get() == 20);
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -1,6 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.azurebfs;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -1,0 +1,4 @@
+package org.apache.hadoop.fs.azurebfs;
+
+public class ITestListBlobProducer {
+}

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.fs.azurebfs.services.ListBlobQueue;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
-import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_MAX_CONSUMER_LAG;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_PRODUCER_QUEUE_MAX_SIZE;
 
 public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
 
@@ -59,7 +59,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
   @Test
   public void testProducerWaitingForConsumerLagToGoDown() throws Exception {
     Configuration configuration = Mockito.spy(getRawConfiguration());
-    configuration.set(FS_AZURE_MAX_CONSUMER_LAG, "10");
+    configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "10");
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
         configuration);
     AbfsClient client = fs.getAbfsClient();
@@ -88,7 +88,9 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
             Mockito.nullable(String.class), Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
-    ListBlobQueue queue = new ListBlobQueue(null);
+    ListBlobQueue queue = new ListBlobQueue(
+        getConfiguration().getProducerQueueMaxSize(),
+        getConfiguration().getBlobDirRenameMaxThread());
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
         null, Mockito.mock(
         TracingContext.class));
@@ -117,7 +119,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
   @Test
   public void testConsumerWhenProducerThrowException() throws Exception {
     Configuration configuration = Mockito.spy(getRawConfiguration());
-    configuration.set(FS_AZURE_MAX_CONSUMER_LAG, "10");
+    configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "10");
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
         configuration);
     AbfsClient client = fs.getAbfsClient();
@@ -139,7 +141,8 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
             Mockito.nullable(String.class), Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
-    ListBlobQueue queue = new ListBlobQueue(null);
+    ListBlobQueue queue = new ListBlobQueue(getConfiguration().getProducerQueueMaxSize(),
+        getConfiguration().getProducerQueueMaxSize());
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
         null, Mockito.mock(
         TracingContext.class));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/DelegationSASGenerator.java
@@ -60,6 +60,7 @@ public class DelegationSASGenerator extends SASGenerator {
       case SASTokenProvider.CREATE_DIRECTORY_OPERATION:
       case SASTokenProvider.WRITE_OPERATION:
       case SASTokenProvider.SET_PROPERTIES_OPERATION:
+      case SASTokenProvider.LEASE_OPERATION:
         sp = "w";
         break;
       case SASTokenProvider.DELETE_OPERATION:


### PR DESCRIPTION
Details:
1. To have a way where in list and rename happens in parallel. List API can give max 5000 results which need the client to call server again with a continuation token. This will need number of sequential call to server and then rename starts. Its a not an optimized use of resources. Will increase latency of rename for dev code, chances of OOM happening(keeping info of all blobs in memory before renaming). In this PR, the rename will start as soon as the client has got some blobs from the server. The producer will call the list API and populate a queue which will be dequeued by the consumer. The producer will pause producing until the consumer-lag comes in control. This design of producer-consumer will be used in the deleteDir API changes as well.
2. Lease control on files being renamed in atomic directory. The source dir will be leased until the whole rename is completed. The blobs in directory are leased when their copy has to start. The reasoning behing this;
```
/*
               * Conditionally get a lease on the source blob to prevent other writers
               * from changing it. This is used for correctness in HBase when log files
               * are renamed. It generally should do no harm other than take a little
               * more time for other rename scenarios. When the HBase master renames a
               * log file folder, the lease locks out other writers.  This
               * prevents a region server that the master thinks is dead, but is still
               * alive, from committing additional updates.  This is different than
               * when HBase runs on HDFS, where the region server recovers the lease
               * on a log file, to gain exclusive access to it, before it splits it.
               */
```
This helps in preventing parallel process in appending a blob which is copy in-progress. Or parallel rename on the same sourceDir.
3. RenamePendingJSON will not have the fileList now. When we need to resume, we will list again(it will return only the ones which are present in the srcDir) and rename.

------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 113, Failures: 0, Errors: 0, Skipped: 2
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:356 » TestTimedOut test timed o...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataContributor:80 » AccessDenied Operat...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataReader:137 » AccessDenied Operation ...
[INFO]
[ERROR] Tests run: 726, Failures: 0, Errors: 3, Skipped: 224
[INFO] Results:
[INFO]
[WARNING] Tests run: 273, Failures: 0, Errors: 0, Skipped: 53

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 113, Failures: 0, Errors: 0, Skipped: 3
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsListStatusRemoteIterator.testWithAbfsIteratorDisabled:168 [After removing every iterm found from the iterator, there should be no more elements in the fileNames] expected:<[0]> but was:<[1]>[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:356 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 726, Failures: 1, Errors: 1, Skipped: 180
[INFO] Results:
[INFO]
[WARNING] Tests run: 273, Failures: 0, Errors: 0, Skipped: 41

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 113, Failures: 0, Errors: 0, Skipped: 3
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsStatistics.testCreateStatistics:108->AbstractAbfsIntegrationTest.assertAbfsStatistics:505->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 Mismatch in directories_created expected:<2> but was:<1>
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testCheckAccessForAccountWithoutNS:191 Expecting org.apache.hadoop.security.AccessControlException with text "This request is not authorized to perform this operation using this permission.", 403 but got : "void"
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:356 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 726, Failures: 2, Errors: 1, Skipped: 278
[INFO] Results:
[INFO]
[WARNING] Tests run: 273, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 113, Failures: 0, Errors: 0, Skipped: 3
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsStatistics.testCreateStatistics:108->AbstractAbfsIntegrationTest.assertAbfsStatistics:505->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 Mismatch in directories_created expected:<2> but was:<1>
[ERROR]   ITestAzureBlobFileSystemCheckAccess.testCheckAccessForAccountWithoutNS:191 Expecting org.apache.hadoop.security.AccessControlException with text "This request is not authorized to perform this operation using this permission.", 403 but got : "void"
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemFlush.testTracingHeaderForAppendBlob:319 » IO AppendBl...
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:356 » TestTimedOut test timed o...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataContributor:80 » AbfsRestOperation O...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataReader:137 » AccessDenied Operation ...
[INFO]
[ERROR] Tests run: 726, Failures: 2, Errors: 4, Skipped: 284
[INFO] Results:
[INFO]
[WARNING] Tests run: 273, Failures: 0, Errors: 0, Skipped: 57

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 113, Failures: 0, Errors: 0, Skipped: 2
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsListStatusRemoteIterator.testAbfsIteratorWithHasNext:88 [After removing every iterm found from the iterator, there should be no more elements in the fileNames] expected:<[0]> but was:<[1]>
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:356 » TestTimedOut test timed o...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataContributor:80 » AccessDenied Operat...
[ERROR]   ITestAzureBlobFileSystemOauth.testBlobDataReader:137 » AccessDenied Operation ...
[INFO]
[ERROR] Tests run: 726, Failures: 1, Errors: 3, Skipped: 224
[INFO] Results:
[INFO]
[WARNING] Tests run: 273, Failures: 0, Errors: 0, Skipped: 53

Time taken: 46 mins 23 secs.