### PR TITLE
Enhanced error message for read on implicit Directory

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1254,7 +1254,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             throw new AbfsRestOperationException(
                     AzureServiceErrorCode.PATH_NOT_FOUND.getStatusCode(),
                     AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
-                    "openFileForRead must be used with files and not directories",
+                    "openFileForRead must be used with files and not directories. " +
+                            "Attempt made for read on implicit directory.",
                     null);
           } else {
             throw e;
@@ -1282,7 +1283,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         throw new AbfsRestOperationException(
                 AzureServiceErrorCode.PATH_NOT_FOUND.getStatusCode(),
                 AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
-                "openFileForRead must be used with files and not directories",
+                "openFileForRead must be used with files and not directories." +
+                        "Attempt made for read on explicit directory.",
                 null);
       }
 


### PR DESCRIPTION
Enhancing the error message to include information about whether read is called incorrectly on an implicit or explicit directory.