### PR TITLE
Unify fallback dependent api

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1016,11 +1016,10 @@ public class AzureBlobFileSystem extends FileSystem
          */
         fileStatus = abfsStore.getFileStatus(qualifiedPath,
             tracingContext, useBlobEndpoint);
-        if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
-          == PrefixMode.BLOB && fileStatus != null && fileStatus.isDirectory()
-          &&
-          abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath()) &&
-          abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,
+        if (getAbfsStore().getPrefixMode() == PrefixMode.BLOB
+                && fileStatus != null && fileStatus.isDirectory()
+          && abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath())
+          && abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,
               tracingContext)) {
         RenameAtomicityUtils renameAtomicityUtils = new RenameAtomicityUtils(
             this,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1010,26 +1010,28 @@ public class AzureBlobFileSystem extends FileSystem
             OperativeEndpoint.isMkdirEnabledOnDFS(prefixMode, abfsConfiguration) ||
             OperativeEndpoint.isReadEnabledOnDFS(prefixMode, abfsConfiguration));
     try {
-      /**
-       * Get File Status over Blob Endpoint will Have an additional call
-       * to check if directory is implicit.
-       */
-      fileStatus = abfsStore.getFileStatus(qualifiedPath, tracingContext, useBlobEndpoint);
-      if (abfsStore.getPrefixMode() == PrefixMode.BLOB && fileStatus != null && fileStatus.isDirectory()
-              &&
-              abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath()) &&
-              abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,
-                      tracingContext)) {
+        /**
+         * Get File Status over Blob Endpoint will Have an additional call
+         * to check if directory is implicit.
+         */
+        fileStatus = abfsStore.getFileStatus(qualifiedPath,
+            tracingContext, useBlobEndpoint);
+        if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
+          == PrefixMode.BLOB && fileStatus != null && fileStatus.isDirectory()
+          &&
+          abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath()) &&
+          abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,
+              tracingContext)) {
         RenameAtomicityUtils renameAtomicityUtils = new RenameAtomicityUtils(
-                this,
-                new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
-                abfsStore.getRedoRenameInvocation(tracingContext));
+            this,
+            new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
+            abfsStore.getRedoRenameInvocation(tracingContext));
         renameAtomicityUtils.cleanup(
-                new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
+            new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
         throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,
-                AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
-                new FileNotFoundException(
-                        qualifiedPath + ": No such file or directory."));
+            AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
+            new FileNotFoundException(
+                qualifiedPath + ": No such file or directory."));
       }
       return fileStatus;
     } catch (AzureBlobFileSystemException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1009,15 +1009,12 @@ public class AzureBlobFileSystem extends FileSystem
          * Get File Status over Blob Endpoint will Have an additional call
          * to check if directory is implicit.
          */
-        fileStatus = abfsStore.getFileStatusOverBlob(qualifiedPath,
-            tracingContext);
+        fileStatus = abfsStore.getFileStatus(qualifiedPath, tracingContext, true);
       }
       else {
-        fileStatus = abfsStore.getFileStatus(qualifiedPath,
-            tracingContext);
+        fileStatus = abfsStore.getFileStatus(qualifiedPath, tracingContext, false);
       }
-      if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
-          == PrefixMode.BLOB && fileStatus != null && fileStatus.isDirectory()
+      if (abfsStore.getPrefixMode() == PrefixMode.BLOB && fileStatus != null && fileStatus.isDirectory()
           &&
           abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath()) &&
           abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1048,8 +1048,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             // Is a parallel access case, as file which was found to be
             // present went missing by this request.
             throw new ConcurrentWriteOperationDetectedException(
-                    "Parallel access to the create path detected. Failing request "
-                            + "to honor single writer semantics");
+                "Parallel access to the create path detected. Failing request "
+                    + "to honor single writer semantics");
           } else {
             throw ex1;
           }
@@ -1721,19 +1721,21 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         List<BlobProperty> blobProperties = getListBlobs(path, null, tracingContext, 2, true);
         if (blobProperties.size() == 0) {
           throw ex;
-        } else {
+        }
+        else {
+          // TODO: return properties of first child blob here like in wasb after listFileStatus is implemented over blob
           return new VersionedFileStatus(
-                  userName,
-                  primaryUserGroup,
-                  new AbfsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL),
-                  false,
-                  0L,
-                  true,
-                  1,
-                  abfsConfiguration.getAzureBlockSize(),
-                  DateTimeUtils.parseLastModifiedTime(null),
-                  path,
-                  null);
+              userName,
+              primaryUserGroup,
+              new AbfsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL),
+              false,
+              0L,
+              true,
+              1,
+              abfsConfiguration.getAzureBlockSize(),
+              DateTimeUtils.parseLastModifiedTime(null),
+              path,
+              null);
         }
       } else {
         throw ex;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1248,8 +1248,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       VersionedFileStatus fileStatus;
       fileStatus = (VersionedFileStatus) getFileStatus(path, tracingContext, useBlobEndpoint);
 
-      //perfInfo.registerResult(fileStatus);
-
       boolean isDirectory = fileStatus.isDirectory();
 
       final long contentLength = fileStatus.getLen();
@@ -1311,7 +1309,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       }
       VersionedFileStatus fileStatus;
       fileStatus = (VersionedFileStatus) getFileStatus(path, tracingContext, useBlobEndpoint);
-      //perfInfo.registerResult(op.getResult());
 
       final Long contentLength = fileStatus.getLen();
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1046,18 +1046,13 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             useBlobEndpoint = false;
           }
           fileStatus = (VersionedFileStatus) getFileStatus(new Path(relativePath), tracingContext, useBlobEndpoint);
-        } catch (IOException ex) {
-          if (ex instanceof AbfsRestOperationException) {
-            AbfsRestOperationException ex1 = (AbfsRestOperationException) ex;
-            if (ex1.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-              // Is a parallel access case, as file which was found to be
-              // present went missing by this request.
-              throw new ConcurrentWriteOperationDetectedException(
-                      "Parallel access to the create path detected. Failing request "
-                              + "to honor single writer semantics");
-            } else {
-              throw ex1;
-            }
+        } catch (AbfsRestOperationException ex) {
+          if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+            // Is a parallel access case, as file which was found to be
+            // present went missing by this request.
+            throw new ConcurrentWriteOperationDetectedException(
+                    "Parallel access to the create path detected. Failing request "
+                            + "to honor single writer semantics");
           } else {
             throw ex;
           }
@@ -1076,8 +1071,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             // and precondition failure can happen only when another file with
             // different etag got created.
             throw new ConcurrentWriteOperationDetectedException(
-                "Parallel access to the create path detected. Failing request "
-                    + "to honor single writer semantics");
+                    "Parallel access to the create path detected. Failing request "
+                            + "to honor single writer semantics");
           } else {
             throw ex;
           }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1226,14 +1226,14 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
   public AbfsInputStream openFileForRead(final Path path,
       final FileSystem.Statistics statistics, TracingContext tracingContext)
-          throws IOException {
+      throws IOException {
     return openFileForRead(path, Optional.empty(), statistics, tracingContext);
   }
 
   public AbfsInputStream openFileForRead(final Path path,
       final Optional<Configuration> options,
       final FileSystem.Statistics statistics, TracingContext tracingContext)
-      throws AzureBlobFileSystemException, IOException {
+      throws IOException {
     try (AbfsPerfInfo perfInfo = startTracking("openFileForRead", "getPathStatus")) {
       LOG.debug("openFileForRead filesystem: {} path: {}",
               client.getFileSystem(),

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1051,8 +1051,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             // Is a parallel access case, as file which was found to be
             // present went missing by this request.
             throw new ConcurrentWriteOperationDetectedException(
-                    "Parallel access to the create path detected. Failing request "
-                            + "to honor single writer semantics");
+                "Parallel access to the create path detected. Failing request "
+                    + "to honor single writer semantics");
           } else {
             throw ex;
           }
@@ -1071,8 +1071,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             // and precondition failure can happen only when another file with
             // different etag got created.
             throw new ConcurrentWriteOperationDetectedException(
-                    "Parallel access to the create path detected. Failing request "
-                            + "to honor single writer semantics");
+                "Parallel access to the create path detected. Failing request "
+                    + "to honor single writer semantics");
           } else {
             throw ex;
           }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/BlobDirectoryStateHelper.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/BlobDirectoryStateHelper.java
@@ -74,8 +74,7 @@ public class BlobDirectoryStateHelper {
       try {
         FileStatus status = fs.getAbfsStore().getFileStatus(
             path,
-            Mockito.mock(TracingContext.class)
-        );
+            Mockito.mock(TracingContext.class), true);
         return !status.isDirectory();
       }
       catch (AbfsRestOperationException ex) {
@@ -103,7 +102,7 @@ public class BlobDirectoryStateHelper {
       FileStatus status;
       try {
         status = fs.getAbfsStore()
-            .getFileStatus(path, Mockito.mock(TracingContext.class));
+            .getFileStatus(path, Mockito.mock(TracingContext.class), false);
       }
       catch (IOException ex) {
         return false;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import org.apache.hadoop.fs.azurebfs.services.OperativeEndpoint;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,8 +50,15 @@ import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest{
   private static final String RETRY_TEST_TOKEN_PROVIDER = "org.apache.hadoop.fs.azurebfs.oauth2.RetryTestTokenProvider";
 
+  boolean useBlobEndpoint;
   public ITestAbfsRestOperationException() throws Exception {
-    super();
+    super.setup();
+    AzureBlobFileSystemStore abfsStore = getAbfsStore(getFileSystem());
+    PrefixMode prefixMode = abfsStore.getPrefixMode();
+    AbfsConfiguration abfsConfiguration = abfsStore.getAbfsConfiguration();
+    useBlobEndpoint = !(OperativeEndpoint.isIngressEnabledOnDFS(prefixMode, abfsConfiguration) ||
+            OperativeEndpoint.isMkdirEnabledOnDFS(prefixMode, abfsConfiguration) ||
+            OperativeEndpoint.isReadEnabledOnDFS(prefixMode, abfsConfiguration));
   }
 
   @Test
@@ -66,7 +74,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
 
       Assert.assertEquals(4, errorFields.length);
       // Check status message, status code, HTTP Request Type and URL.
-      if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
+      if (useBlobEndpoint) {
         Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
       }
       else {
@@ -87,7 +95,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       if (!getAbfsStore(fs).getAbfsConfiguration().enableAbfsListIterator()) {
         Assert.assertEquals(6, errorFields.length);
         // Check status message, status code, HTTP Request Type and URL.
-        if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
+        if (useBlobEndpoint) {
           Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
         }
         else {
@@ -103,7 +111,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       } else {
         Assert.assertEquals(4, errorFields.length);
         // Check status message, status code, HTTP Request Type and URL.
-        if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
+        if (useBlobEndpoint) {
           Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
         }
         else {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
@@ -44,6 +45,7 @@ import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationVa
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.test.LambdaTestUtils;
 
+import org.checkerframework.common.value.qual.StaticallyExecutable;
 import org.junit.Assume;
 
 import org.junit.Test;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.InvalidConfigurationValueException;
+import org.apache.hadoop.fs.azurebfs.services.OperativeEndpoint;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.test.LambdaTestUtils;
 
@@ -98,9 +99,16 @@ public class ITestAzureBlobFileSystemCreate extends
   private static final Path TEST_FILE_PATH = new Path("testfile");
   private static final Path TEST_FOLDER_PATH = new Path("testFolder");
   private static final String TEST_CHILD_FILE = "childFile";
+  private boolean useBlobEndpoint;
 
   public ITestAzureBlobFileSystemCreate() throws Exception {
-    super();
+    super.setup();
+    AzureBlobFileSystemStore abfsStore = getAbfsStore(getFileSystem());
+    PrefixMode prefixMode = abfsStore.getPrefixMode();
+    AbfsConfiguration abfsConfiguration = abfsStore.getAbfsConfiguration();
+    useBlobEndpoint = !(OperativeEndpoint.isIngressEnabledOnDFS(prefixMode, abfsConfiguration) ||
+            OperativeEndpoint.isMkdirEnabledOnDFS(prefixMode, abfsConfiguration) ||
+            OperativeEndpoint.isReadEnabledOnDFS(prefixMode, abfsConfiguration));
   }
 
   @Test
@@ -1067,7 +1075,7 @@ public class ITestAzureBlobFileSystemCreate extends
     createRequestCount+=2;
 
     // In case of blob endpoint getFileStatus makes additional call to check if path is implicit
-    if (fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB) {
+    if (useBlobEndpoint) {
       createRequestCount++;
     }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.utils.TracingHeaderValidator;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.AZURE_LIST_MAX_RESULTS;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.assertMkdirs;
@@ -60,7 +62,7 @@ public class ITestAzureBlobFileSystemListStatus extends
 
   @Test
   public void testListPath() throws Exception {
-    Configuration config = new Configuration(this.getRawConfiguration());
+    Configuration config = Mockito.spy(this.getRawConfiguration());
     config.set(AZURE_LIST_MAX_RESULTS, "5000");
     final AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem
         .newInstance(getFileSystem().getUri(), config);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRandomRead.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.UUID;
 
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.OperativeEndpoint;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.services.ITestAbfsClient;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
@@ -597,10 +598,13 @@ public class ITestAzureBlobFileSystemRandomRead extends
     Path testPath = new Path("/testReadFile");
     fs.create(testPath);
     FSDataInputStream in = fs.open(testPath);
-    Mockito.verify(mockClient, Mockito.atLeast(1)).getBlobProperty(
-            Mockito.any(Path.class), Mockito.any(TracingContext.class));
-    Mockito.verify(mockClient, Mockito.times(0)).getPathStatus(
-            Mockito.any(String.class), Mockito.anyBoolean(), Mockito.any(TracingContext.class));
+    if (!OperativeEndpoint.isReadEnabledOnDFS(getPrefixMode(fs), store.getAbfsConfiguration())) {
+      Mockito.verify(mockClient, Mockito.atLeast(1)).getBlobProperty(
+              Mockito.any(Path.class), Mockito.any(TracingContext.class));
+    } else {
+      Mockito.verify(mockClient, Mockito.times(1)).getPathStatus(
+              Mockito.any(String.class), Mockito.anyBoolean(), Mockito.any(TracingContext.class));
+    }
   }
 
   @Test


### PR DESCRIPTION
PR to make sure that if any API fallbacks to DFS endpoint, the dependent getFileStatus call should also go to DFS endpoint. Also refactored the code for openFileForRead and openFileForWrite to depend only on getFileStatus call.