### PR TITLE
Added Test For Special Scenario and Debug Logs for listStatus()

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1943,15 +1943,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         FileStatus status = getFileStatus(path, tracingContext, true);
         if (status.isFile()) {
           fileStatuses.add(status);
-          return continuation;
         }
       }
 
-      LOG.debug("List Status on Blob Endpoint on filesystem: {} path: {} received {} objects from server",
-          client.getFileSystem(), path, objectCountReturnedByServer);
-
-      LOG.debug("List Status on Blob Endpoint on filesystem: {} path: {} returned {} objects to user",
-          client.getFileSystem(), path, fileStatuses.size());
+      LOG.debug("List Status on Blob Endpoint on filesystem: {} path: {} received {} objects from server and returned {} objects to user",
+          client.getFileSystem(), path, objectCountReturnedByServer, fileStatuses.size());
 
       return continuation;
     }


### PR DESCRIPTION
Added test for a special scenario that was leading to duplicate entry in listStatus call made over DFS endpoint.
Added logs on reporting:
1. How many objects were returned by server in each List Blob call made on prefix with a marker.
2. How many objects were returned by server in complete ListStatus() call made on a path.
3. How man objects Driver returned to caller in complete ListStatus() call made on a path.