### PR TITLE
Delete over blobendpoint.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -249,6 +249,10 @@ public class AbfsConfiguration{
       DefaultValue = 0)
   private int blobDirRenameMaxThread;
 
+  @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_DIR_DELETE_MAX_THREAD,
+      DefaultValue = 0)
+  private int blobDirDeleteMaxThread;
+
   @LongConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS,
       DefaultValue = 1_000L)
   private long blobCopyProgressPollWaitMillis;
@@ -1108,6 +1112,10 @@ public class AbfsConfiguration{
 
   public int getBlobDirRenameMaxThread() {
     return blobDirRenameMaxThread;
+  }
+
+  public int getBlobDirDeleteMaxThread() {
+    return blobDirDeleteMaxThread;
   }
 
   public long getBlobCopyProgressPollWaitMillis() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -260,7 +260,7 @@ public class AbfsConfiguration{
   private int blobDirRenameMaxThread;
 
   @IntegerConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_DIR_DELETE_MAX_THREAD,
-      DefaultValue = 0)
+      DefaultValue = DEFAULT_FS_AZURE_BLOB_DELETE_THREAD)
   private int blobDirDeleteMaxThread;
 
   @LongConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -895,6 +895,9 @@ public class AzureBlobFileSystem extends FileSystem
         return false;
       }
 
+      /*
+      * For DFS root directory deletion,
+      */
       if (getAbfsStore().getPrefixMode() == PrefixMode.DFS) {
         return deleteRoot();
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -896,8 +896,10 @@ public class AzureBlobFileSystem extends FileSystem
       }
 
       /*
-      * For DFS root directory deletion,
-      */
+       * For DFS root directory deletion, direct DELETE Path API on root doesn't
+       * work, the server returns: "The request URI is invalid.", 400, DELETE.
+       * Hence, there is a special handling for root deletion on DFS endpoint
+       */
       if (getAbfsStore().getPrefixMode() == PrefixMode.DFS) {
         return deleteRoot();
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -870,7 +870,7 @@ public class AzureBlobFileSystem extends FileSystem
       }
     }
 
-    if (f.isRoot()) {
+    if (f.isRoot() && getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.DFS) {
       if (!recursive) {
         return false;
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -890,12 +890,14 @@ public class AzureBlobFileSystem extends FileSystem
       }
     }
 
-    if (f.isRoot() && getAbfsStore().getAbfsConfiguration().getPrefixMode() == PrefixMode.DFS) {
+    if (f.isRoot()) {
       if (!recursive) {
         return false;
       }
 
-      return deleteRoot();
+      if (getAbfsStore().getPrefixMode() == PrefixMode.DFS) {
+        return deleteRoot();
+      }
     }
 
     try {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1815,8 +1815,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   /**
    * If parent blob is implicit directory and in case the blob deleted was the
    * only blob in the directory, it will render path as non-existing. To prevent
-   * that happening, we check if the parent directory is implicit and if yes, we
-   * create marker-based directory.
+   * that happening, client create marker-based directory.
    *
    * @param path path getting deleted
    * @param tracingContext tracingContext to trace the API flow

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1779,6 +1779,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
               AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
               ex.getErrorMessage(), ex);
         }
+        throw ex;
       }
       LOG.debug(
           String.format("Path %s is not a directory", path.toUri().getPath()));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -212,6 +212,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   private final AbfsPerfTracker abfsPerfTracker;
   private final AbfsCounters abfsCounters;
   private PrefixMode prefixMode;
+
   /**
    * The set of directories where we should store files as append blobs.
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1622,7 +1622,10 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
               tracingContext).getResult()
           .getBlobList();
       if (blobList.getBlobPropertyList().size() == 0) {
-        throw ex;
+        throw new AbfsRestOperationException(
+            ex.getStatusCode(),
+            AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
+            ex.getErrorMessage(), ex);
       }
       String nextMarker = blobList.getNextMarker();
       listBlobQueue = new ListBlobQueue(blobList);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1784,6 +1784,16 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     }
   }
 
+  /**
+   * If parent blob is implicit directory and in case the blob deleted was the
+   * only blob in the directory, it will render path as non-existing. To prevent
+   * that happening, we check if the parent directory is implicit and if yes, we
+   * create marker-based directory.
+   *
+   * @param path path getting deleted
+   * @param tracingContext tracingContext to trace the API flow
+   * @throws IOException
+   */
   private void deleteCheckOnParentBlob(final Path path,
       final TracingContext tracingContext) throws IOException {
     if (path.isRoot()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1598,7 +1598,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         : FORWARD_SLASH);
 
     try {
-      pathProperty = getBlobProperty(path, tracingContext);
+      if(!path.isRoot()) {
+        pathProperty = getBlobProperty(path, tracingContext);
+      }
     } catch (AbfsRestOperationException ex) {
       if(ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
         throw ex;
@@ -1629,7 +1631,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       pathProperty.setPath(path);
     }
 
-    if (!pathProperty.getIsDirectory()) {
+    if (pathProperty != null && !pathProperty.getIsDirectory()) {
       deleteBlob(path, null, tracingContext);
       return;
     }
@@ -1656,7 +1658,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       }
       if(!recursive && blobList.getBlobPropertyList().size() > 0) {
         throw new IOException(
-            "Non-recursive delete of non-empty directory " + pathProperty.getIsDirectory());
+            "Non-recursive delete of non-empty directory " + (pathProperty != null ? pathProperty.getIsDirectory() : ""));
       }
       List<Future> futureList = new ArrayList<>();
       for (BlobProperty blobProperty : blobList.getBlobPropertyList()) {
@@ -1682,7 +1684,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         }
       }
     }
-    client.deleteBlobPath(pathProperty.getPath(), null, tracingContext);
+    if(pathProperty != null) {
+      client.deleteBlobPath(pathProperty.getPath(), null, tracingContext);
+    }
   }
 
   public FileStatus getFileStatus(final Path path,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1783,7 +1783,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       }
     }
     createParentDirectory(path, tracingContext);
-    LOG.debug(String.format("Deletion of Path %s completed"), srcPathStr);
+    LOG.debug(String.format("Deletion of Path %s completed", srcPathStr));
   }
 
   private void orchestrateBlobDirDeletion(final Path path,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1830,6 +1830,9 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       return;
     }
     Path parentPath = path.getParent();
+    if (parentPath.isRoot()) {
+      return;
+    }
     try {
       getBlobProperty(parentPath, tracingContext);
     } catch (AbfsRestOperationException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1768,9 +1768,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       LOG.debug(String.format("Path %s doesn't have child-blobs", srcPathStr));
       if (!path.isRoot()) {
         try {
-          LOG.debug(String.format("Deleting path %s", srcPathStr));
           client.deleteBlobPath(path, null, tracingContext);
-          LOG.debug(String.format("Path deleted %s", srcPathStr));
         } catch (AbfsRestOperationException ex) {
           if (ex.getStatusCode() == HTTP_NOT_FOUND) {
             LOG.error(String.format("Path %s doesn't exist", srcPathStr), ex);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1653,16 +1653,18 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
      */
     if (!path.isRoot()) {
       Path parentPath = path.getParent();
-      try {
-        getBlobProperty(parentPath, tracingContext);
-      } catch (AbfsRestOperationException ex) {
-        if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-          throw ex;
+      if (!parentPath.isRoot()) {
+        try {
+          getBlobProperty(parentPath, tracingContext);
+        } catch (AbfsRestOperationException ex) {
+          if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
+            throw ex;
+          }
+          createDirectory(parentPath, null, FsPermission.getDirDefault(),
+              FsPermission.getUMask(
+                  getAbfsConfiguration().getRawConfiguration()),
+              tracingContext);
         }
-        createDirectory(parentPath, null, FsPermission.getDirDefault(),
-            FsPermission.getUMask(
-                getAbfsConfiguration().getRawConfiguration()),
-            tracingContext);
       }
     }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1754,8 +1754,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       ListBlobQueue queue = new ListBlobQueue(blobList.getBlobPropertyList(),
           getAbfsConfiguration().getProducerQueueMaxSize(),
           getAbfsConfiguration().getBlobDirDeleteMaxThread());
-      ListBlobProducer producer = new ListBlobProducer(listSrc, client, queue,
-          blobList.getNextMarker(), tracingContext);
+      if (blobList.getNextMarker() != null) {
+        new ListBlobProducer(listSrc, client, queue,
+            blobList.getNextMarker(), tracingContext);
+      } else {
+        queue.complete();
+      }
       ListBlobConsumer consumer = new ListBlobConsumer(queue);
       deleteCheckOnParentBlob(path, tracingContext);
       deleteOnConsumedBlobs(path, consumer, tracingContext);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1144,13 +1144,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         checkParentChainForFile(path, tracingContext, keysToCreateAsFolder);
         boolean blobOverwrite = abfsConfiguration.isEnabledBlobMkdirOverwrite();
 
-        HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(X_MS_META_HDI_ISFOLDER, TRUE);
-        createFile(path, statistics, blobOverwrite,
-                permission, umask, tracingContext, metadata);
+        createDirectoryMarkerBlob(path, statistics, permission, umask, tracingContext,
+            blobOverwrite);
         for (Path pathToCreate: keysToCreateAsFolder) {
-            createFile(pathToCreate, statistics, blobOverwrite,
-                    permission, umask, tracingContext, metadata);
+          createDirectoryMarkerBlob(pathToCreate, statistics, permission, umask,
+              tracingContext, blobOverwrite);
         }
         return;
       }
@@ -1171,6 +1169,18 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
               tracingContext);
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
     }
+  }
+
+  private void createDirectoryMarkerBlob(final Path path,
+      final FileSystem.Statistics statistics,
+      final FsPermission permission,
+      final FsPermission umask,
+      final TracingContext tracingContext,
+      final boolean blobOverwrite) throws IOException {
+    HashMap<String, String> metadata = new HashMap<>();
+    metadata.put(X_MS_META_HDI_ISFOLDER, TRUE);
+    createFile(path, statistics, blobOverwrite,
+        permission, umask, tracingContext, metadata);
   }
 
   /**
@@ -1771,32 +1781,29 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         queue.complete();
       }
       ListBlobConsumer consumer = new ListBlobConsumer(queue);
-      createParentDirectoryIfImplicitOfPathDeleted(path, tracingContext);
       deleteOnConsumedBlobs(path, consumer, tracingContext);
-      return;
-    }
-    LOG.debug(String.format("Path %s doesn't have child-blobs", srcPathStr));
-    if (!path.isRoot()) {
-      try {
-        getBlobProperty(path, tracingContext);
-      } catch (AbfsRestOperationException ex) {
-        if (ex.getStatusCode() == HTTP_NOT_FOUND) {
-          LOG.error(
-              String.format("Path %s doesn't exist", srcPathStr));
-          throw new AbfsRestOperationException(
-              ex.getStatusCode(),
-              AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
-              ex.getErrorMessage(), ex);
+    } else {
+      LOG.debug(String.format("Path %s doesn't have child-blobs", srcPathStr));
+      if (!path.isRoot()) {
+        try {
+          LOG.debug(String.format("Deleting path %s", srcPathStr));
+          client.deleteBlobPath(path, null, tracingContext);
+          LOG.debug(String.format("Path deleted %s", srcPathStr));
+        } catch (AbfsRestOperationException ex) {
+          if (ex.getStatusCode() == HTTP_NOT_FOUND) {
+            LOG.error(
+                String.format("Path %s doesn't exist", srcPathStr));
+            throw new AbfsRestOperationException(
+                ex.getStatusCode(),
+                AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
+                ex.getErrorMessage(), ex);
+          }
+          throw ex;
         }
-        throw ex;
       }
-      LOG.debug(
-          String.format("Path %s is not a directory", srcPathStr));
-      createParentDirectoryIfImplicitOfPathDeleted(path, tracingContext);
-      LOG.debug(String.format("Deleting path %s", srcPathStr));
-      client.deleteBlobPath(path, null, tracingContext);
-      LOG.debug(String.format("Path deleted %s", srcPathStr));
     }
+    createParentDirectory(path, tracingContext);
+    LOG.debug(String.format("Deletion of Path %s completed"), srcPathStr);
   }
 
   /**
@@ -1809,7 +1816,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @param tracingContext tracingContext to trace the API flow
    * @throws IOException
    */
-  private void createParentDirectoryIfImplicitOfPathDeleted(final Path path,
+  private void createParentDirectory(final Path path,
       final TracingContext tracingContext) throws IOException {
     if (path.isRoot()) {
       return;
@@ -1818,32 +1825,18 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     if (parentPath.isRoot()) {
       return;
     }
+
     String srcPathStr = path.toUri().getPath();
     String srcParentPathSrc = parentPath.toUri().getPath();
-    LOG.debug(String.format("Checking parent of Path %s : %s exists",
+    LOG.debug(String.format(
+        "Parent of Path %s : %s doesn't exist. Creating directory for the parentPath",
         srcPathStr, srcParentPathSrc));
-    try {
-      getBlobProperty(parentPath, tracingContext);
-      LOG.debug(
-          String.format("Parent of Path %s : %s exists", srcPathStr,
-              srcParentPathSrc));
-    } catch (AbfsRestOperationException ex) {
-      if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        LOG.error(String.format("Checking parent of Path %s : %s failed",
-            srcPathStr, srcParentPathSrc), ex);
-        throw ex;
-      }
-      LOG.debug(String.format(
-          "Parent of Path %s : %s doesn't exist. Creating directory for the parentPath",
-          srcPathStr, srcParentPathSrc));
-      createDirectory(parentPath, null, FsPermission.getDirDefault(),
-          FsPermission.getUMask(
-              getAbfsConfiguration().getRawConfiguration()),
-          tracingContext);
-
-      LOG.debug(String.format("Directory for parent of Path %s : %s created",
-          srcPathStr, srcParentPathSrc));
-    }
+    createDirectoryMarkerBlob(parentPath, null, FsPermission.getDirDefault(),
+        FsPermission.getUMask(
+            getAbfsConfiguration().getRawConfiguration()),
+        tracingContext, true);
+    LOG.debug(String.format("Directory for parent of Path %s : %s created",
+        srcPathStr, srcParentPathSrc));
   }
 
   /**
@@ -1919,7 +1912,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           LOG.debug(String.format("Deleting Path %s failed", srcPathStr), ex);
           throw ex;
         }
-        LOG.debug(String.format("Path %s is an implicit directory", srcPathStr));
+        LOG.debug(
+            String.format("Path %s is an implicit directory", srcPathStr));
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1793,7 +1793,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         throw ex;
       }
 
-      BlobList blobList = client.getListBlobs(null, listSrc, null,
+      BlobList blobList = client.getListBlobs(null, listSrc, null,null,
               tracingContext).getResult()
           .getBlobList();
       if (blobList.getBlobPropertyList().size() == 0) {
@@ -1901,6 +1901,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           throw new RuntimeException(e);
         }
       }
+      deleteBlobExecutorService.shutdown();
     }
     if (pathProperty != null) {
       client.deleteBlobPath(pathProperty.getPath(), null, tracingContext);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -257,6 +257,7 @@ public final class ConfigurationKeys {
    */
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
   public static final String FS_AZURE_BLOB_DIR_RENAME_MAX_THREAD = "fs.azure.blob.dir.rename.max.thread";
+  public static final String FS_AZURE_BLOB_DIR_DELETE_MAX_THREAD = "fs.azure.blob.dir.delete.max.thread";
   public static final String FS_AZURE_BLOB_COPY_PROGRESS_POLL_WAIT_MILLIS = "fs.azure.blob.copy.progress.poll.wait.millis";
 
   public static final String FS_AZURE_ENABLE_BLOB_ENDPOINT = "fs.azure.enable.blob.endpoint";

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -126,7 +126,7 @@ public final class FileSystemConfigurations {
 
   // To have functionality similar to drop1 delete is going to wasb by default for now.
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
-  public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = true;
+  public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = false;
   public static final int DEFAULT_FS_AZURE_MAX_CONSUMER_LAG = 7000;
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -136,6 +136,7 @@ public final class FileSystemConfigurations {
   public static final boolean DEFAULT_FS_AZURE_LEASE_CREATE_NON_RECURSIVE = false;
 
   public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;
+  public static final int DEFAULT_FS_AZURE_BLOB_DELETE_THREAD = 5;
 
   /**
    * Limit of queued block upload operations before writes

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -131,7 +131,6 @@ public final class FileSystemConfigurations {
   // To have functionality similar to drop1 delete is going to wasb by default for now.
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_RENAME = false;
   public static final boolean DEFAULT_FS_AZURE_REDIRECT_DELETE = false;
-  public static final int DEFAULT_FS_AZURE_MAX_CONSUMER_LAG = 7000;
   public static final int DEFAULT_FS_AZURE_PRODUCER_QUEUE_MAX_SIZE = 10000;
   public static final boolean DEFAULT_FS_AZURE_LEASE_CREATE_NON_RECURSIVE = false;
   public static final int DEFAULT_FS_AZURE_BLOB_RENAME_THREAD = 5;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
@@ -232,14 +232,16 @@ public class ITestAzureBlobFileSystemBlobConfig
     isDeleteOverNativeFS[0] = false;
     Boolean[] isDeleteOverDFSEndpoint = new Boolean[1];
     isDeleteOverDFSEndpoint[0] = false;
+    Boolean[] isDeleteOverAbfsBlobEndpoint = new Boolean[1];
+    isDeleteOverAbfsBlobEndpoint[0] = false;
 
     countDeleteOverAbfsAndWasb(nativeAzureFileSystem, client, isDeleteOverNativeFS,
-        isDeleteOverDFSEndpoint);
+        isDeleteOverDFSEndpoint, isDeleteOverAbfsBlobEndpoint);
 
     fs.create(new Path("/file"));
     fs.delete(new Path("/file"), true);
 
-    Assert.assertTrue(isDeleteOverDFSEndpoint[0]);
+    Assert.assertTrue(isDeleteOverDFSEndpoint[0] || isDeleteOverAbfsBlobEndpoint[0]);
     Assert.assertFalse(isDeleteOverNativeFS[0]);
   }
 
@@ -257,9 +259,11 @@ public class ITestAzureBlobFileSystemBlobConfig
     isDeleteOverNativeFS[0] = false;
     Boolean[] isDeleteOverDFSEndpoint = new Boolean[1];
     isDeleteOverDFSEndpoint[0] = false;
+    Boolean[] isDeleteOverAbfsBlobEndpoint = new Boolean[1];
+    isDeleteOverAbfsBlobEndpoint[0] = false;
 
     countDeleteOverAbfsAndWasb(nativeAzureFileSystem, client, isDeleteOverNativeFS,
-        isDeleteOverDFSEndpoint);
+        isDeleteOverDFSEndpoint, isDeleteOverAbfsBlobEndpoint);
 
     fs.create(new Path("/file"));
     fs.delete(new Path("/file"), true);
@@ -282,9 +286,11 @@ public class ITestAzureBlobFileSystemBlobConfig
     isDeleteOverNativeFS[0] = false;
     Boolean[] isDeleteOverDFSEndpoint = new Boolean[1];
     isDeleteOverDFSEndpoint[0] = false;
+    Boolean[] isDeleteOverAbfsBlobEndpoint = new Boolean[1];
+    isDeleteOverAbfsBlobEndpoint[0] = false;
 
     countDeleteOverAbfsAndWasb(nativeAzureFileSystem, client, isDeleteOverNativeFS,
-        isDeleteOverDFSEndpoint);
+        isDeleteOverDFSEndpoint, isDeleteOverAbfsBlobEndpoint);
 
     fs.create(new Path("/file"));
     fs.delete(new Path("/file"), true);
@@ -307,9 +313,11 @@ public class ITestAzureBlobFileSystemBlobConfig
     isDeleteOverNativeFS[0] = false;
     Boolean[] isDeleteOverDFSEndpoint = new Boolean[1];
     isDeleteOverDFSEndpoint[0] = false;
+    Boolean[] isDeleteOverAbfsBlobEndpoint = new Boolean[1];
+    isDeleteOverAbfsBlobEndpoint[0] = false;
 
     countDeleteOverAbfsAndWasb(nativeAzureFileSystem, client, isDeleteOverNativeFS,
-        isDeleteOverDFSEndpoint);
+        isDeleteOverDFSEndpoint, isDeleteOverAbfsBlobEndpoint);
 
     fs.create(new Path("/file"));
     fs.delete(new Path("/file"), true);
@@ -323,7 +331,10 @@ public class ITestAzureBlobFileSystemBlobConfig
     AzureBlobFileSystem fs = Mockito.spy(createFileSystemForEndpointConfigPair(
         FS_AZURE_REDIRECT_RENAME, false, false));
 
-    NativeAzureFileSystem nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    NativeAzureFileSystem nativeAzureFileSystem = null;
+    if (fs.getNativeFs() != null) {
+      nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    }
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
     assignStoreMocksToFs(fs, nativeAzureFileSystem, store, client);
@@ -404,7 +415,10 @@ public class ITestAzureBlobFileSystemBlobConfig
     AzureBlobFileSystem fs = Mockito.spy(createFileSystemForEndpointConfigPair(
         FS_AZURE_REDIRECT_RENAME, false, true));
 
-    NativeAzureFileSystem nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    NativeAzureFileSystem nativeAzureFileSystem = null;
+    if (fs.getNativeFs() != null) {
+      nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    }
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
     assignStoreMocksToFs(fs, nativeAzureFileSystem, store, client);
@@ -431,7 +445,10 @@ public class ITestAzureBlobFileSystemBlobConfig
     AzureBlobFileSystem fs = Mockito.spy(createFileSystemForEndpointConfigPair(
         FS_AZURE_INGRESS_FALLBACK_TO_DFS, true, false));
 
-    NativeAzureFileSystem nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    NativeAzureFileSystem nativeAzureFileSystem = null;
+    if (fs.getNativeFs() != null) {
+      nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    }
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
     assignStoreMocksToFs(fs, nativeAzureFileSystem, store, client);
@@ -469,7 +486,10 @@ public class ITestAzureBlobFileSystemBlobConfig
     AzureBlobFileSystem fs = Mockito.spy(createFileSystemForEndpointConfigPair(
         FS_AZURE_INGRESS_FALLBACK_TO_DFS, false, false));
 
-    NativeAzureFileSystem nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    NativeAzureFileSystem nativeAzureFileSystem = null;
+    if (fs.getNativeFs() != null) {
+      nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    }
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
     assignStoreMocksToFs(fs, nativeAzureFileSystem, store, client);
@@ -507,7 +527,10 @@ public class ITestAzureBlobFileSystemBlobConfig
     AzureBlobFileSystem fs = Mockito.spy(createFileSystemForEndpointConfigPair(
         FS_AZURE_INGRESS_FALLBACK_TO_DFS, true, true));
 
-    NativeAzureFileSystem nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    NativeAzureFileSystem nativeAzureFileSystem = null;
+    if (fs.getNativeFs() != null) {
+      nativeAzureFileSystem = Mockito.spy(fs.getNativeFs());
+    }
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(fs.getAbfsClient());
     assignStoreMocksToFs(fs, nativeAzureFileSystem, store, client);
@@ -609,11 +632,17 @@ public class ITestAzureBlobFileSystemBlobConfig
   private void countDeleteOverAbfsAndWasb(final NativeAzureFileSystem nativeAzureFileSystem,
       final AbfsClient client,
       final Boolean[] isDeleteOverNativeFS,
-      final Boolean[] isDeleteOverDFSEndpoint) throws IOException {
+      final Boolean[] isDeleteOverDFSEndpoint,
+      final Boolean[] isDeleteOverAbfsBlobEndpoint) throws IOException {
     Mockito.doAnswer(answer -> {
       isDeleteOverDFSEndpoint[0] = true;
       return answer.callRealMethod();
     }).when(client).deletePath(Mockito.any(String.class), Mockito.anyBoolean(), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+
+    Mockito.doAnswer(answer -> {
+      isDeleteOverAbfsBlobEndpoint[0] = true;
+      return answer.callRealMethod();
+    }).when(client).deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
 
     if(nativeAzureFileSystem != null) {
       Mockito.doAnswer(answer -> {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -401,4 +401,17 @@ public class ITestAzureBlobFileSystemDelete extends
     fs.mkdirs(new Path("/testDir"));
     Assertions.assertThat(fs.delete(new Path("/"), false)).isFalse();
   }
+
+  @Test
+  public void testDeleteCheckIfParentLMTChange() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    fs.mkdirs(new Path("/dir1/dir2"));
+    fs.create(new Path("/dir1/dir2/file"));
+    FileStatus status = fs.getFileStatus(new Path("/dir1"));
+    Long lmt = status.getModificationTime();
+
+    fs.delete(new Path("/dir1/dir2"), true);
+    Long newLmt = fs.getFileStatus(new Path("/dir1")).getModificationTime();
+    Assertions.assertThat(lmt).isEqualTo(newLmt);
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -339,8 +339,7 @@ public class ITestAzureBlobFileSystemDelete extends
     Mockito.doAnswer(answer -> {
           String marker = answer.getArgument(0);
           String prefix = answer.getArgument(1);
-          Integer maxResult = answer.getArgument(2);
-          TracingContext context = answer.getArgument(3);
+          TracingContext context = answer.getArgument(4);
           return client.getListBlobs(marker, prefix, null, 1, context);
         })
         .when(spiedClient)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -394,4 +394,11 @@ public class ITestAzureBlobFileSystemDelete extends
       fs.delete(new Path("/testDir"), true);
     });
   }
+
+  @Test
+  public void testDeleteRootWithNonRecursion() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    fs.mkdirs(new Path("/testDir"));
+    Assertions.assertThat(fs.delete(new Path("/"), false)).isFalse();
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
@@ -23,7 +23,6 @@ import java.net.HttpURLConnection;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -35,7 +34,6 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
-@Ignore
 public class ITestAzureBlobFileSystemExplictImplicitRename
     extends AbstractAbfsIntegrationTest {
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -34,6 +35,7 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 
+@Ignore
 public class ITestAzureBlobFileSystemExplictImplicitRename
     extends AbstractAbfsIntegrationTest {
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -440,12 +440,14 @@ public class ITestAzureBlobFileSystemRename extends
      * Check if the fs.delete is on the renameJson file.
      */
     AtomicInteger deletedCount = new AtomicInteger(0);
+    AtomicBoolean srcSuffixDeletion = new AtomicBoolean(false);
     Mockito.doAnswer(answer -> {
           Path path = answer.getArgument(0);
           Boolean recursive = answer.getArgument(1);
           Assert.assertTrue(
               ("/" + "hbase/test1/test2/test3" + SUFFIX).equalsIgnoreCase(
                   path.toUri().getPath()));
+          srcSuffixDeletion.set(true);
           deletedCount.incrementAndGet();
           return fs.delete(path, recursive);
         })
@@ -463,11 +465,17 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           String leaseId = answer.getArgument(1);
           TracingContext tracingContext = answer.getArgument(2);
-          Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
-                  || "/hbase/test1/test2/test3".equalsIgnoreCase(
-                  path.toUri().getPath()));
-          deletedCount.incrementAndGet();
+          if (srcSuffixDeletion.get()) {
+            Assert.assertTrue(
+                ("/" + "hbase/test1/test2/test3" + SUFFIX).equalsIgnoreCase(
+                    path.toUri().getPath()));
+          } else {
+            Assert.assertTrue(
+                ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
+                    || "/hbase/test1/test2/test3".equalsIgnoreCase(
+                    path.toUri().getPath()));
+            deletedCount.incrementAndGet();
+          }
           client.deleteBlobPath(path, leaseId, tracingContext);
           return null;
         })
@@ -571,11 +579,13 @@ public class ITestAzureBlobFileSystemRename extends
      * Check if the fs.delete is on the renameJson file.
      */
     AtomicInteger deletedCount = new AtomicInteger(0);
+    AtomicBoolean srcDirSuffixDeletion = new AtomicBoolean(false);
     Mockito.doAnswer(answer -> {
           Path path = answer.getArgument(0);
           Boolean recursive = answer.getArgument(1);
           Assert.assertTrue(("/" + "hbase/test1/test2" + SUFFIX).equalsIgnoreCase(
               path.toUri().getPath()));
+          srcDirSuffixDeletion.set(true);
           deletedCount.incrementAndGet();
           return fs.delete(path, recursive);
         })
@@ -593,10 +603,16 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           String leaseId = answer.getArgument(1);
           TracingContext tracingContext = answer.getArgument(2);
-          Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
-                  || "/hbase/test1/test2".equalsIgnoreCase(path.toUri().getPath()));
-          deletedCount.incrementAndGet();
+          if (srcDirSuffixDeletion.get()) {
+            Assert.assertTrue(("/" + "hbase/test1/test2" + SUFFIX).equalsIgnoreCase(
+                path.toUri().getPath()));
+          } else {
+            Assert.assertTrue(
+                ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
+                    || "/hbase/test1/test2".equalsIgnoreCase(
+                    path.toUri().getPath()));
+            deletedCount.incrementAndGet();
+          }
           client.deleteBlobPath(path, leaseId, tracingContext);
           return null;
         })
@@ -708,11 +724,13 @@ public class ITestAzureBlobFileSystemRename extends
      * Check if the fs.delete is on the renameJson file.
      */
     AtomicInteger deletedCount = new AtomicInteger(0);
+    AtomicBoolean srcSuffixDeletion = new AtomicBoolean(false);
     Mockito.doAnswer(answer -> {
           Path path = answer.getArgument(0);
           Boolean recursive = answer.getArgument(1);
           Assert.assertTrue(("/" + "hbase/test1/test2" + SUFFIX).equalsIgnoreCase(
               path.toUri().getPath()));
+          srcSuffixDeletion.set(true);
           deletedCount.incrementAndGet();
           return fs.delete(path, recursive);
         })
@@ -730,9 +748,16 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           String leaseId = answer.getArgument(1);
           TracingContext tracingContext = answer.getArgument(2);
-          Assert.assertTrue(
-              ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath()) || "/hbase/test1/test2".equalsIgnoreCase(path.toUri().getPath()));
-          deletedCount.incrementAndGet();
+          if (srcSuffixDeletion.get()) {
+            Assert.assertTrue(("/" + "hbase/test1/test2" + SUFFIX).equalsIgnoreCase(
+                path.toUri().getPath()));
+          } else {
+            Assert.assertTrue(
+                ("/" + failedCopyPath).equalsIgnoreCase(path.toUri().getPath())
+                    || "/hbase/test1/test2".equalsIgnoreCase(
+                    path.toUri().getPath()));
+            deletedCount.incrementAndGet();
+          }
           client.deleteBlobPath(path, leaseId, tracingContext);
           return null;
         })
@@ -1048,11 +1073,13 @@ public class ITestAzureBlobFileSystemRename extends
      * Check if the fs.delete is on the renameJson file.
      */
     AtomicInteger deletedCount = new AtomicInteger(0);
+    AtomicBoolean deletedSrcDirSuffix = new AtomicBoolean(false);
     Mockito.doAnswer(answer -> {
           Path path = answer.getArgument(0);
           Boolean recursive = answer.getArgument(1);
           Assert.assertTrue(
               (srcDir + SUFFIX).equalsIgnoreCase(path.toUri().getPath()));
+          deletedSrcDirSuffix.set(true);
           deletedCount.incrementAndGet();
           return fs.delete(path, recursive);
         })
@@ -1070,8 +1097,14 @@ public class ITestAzureBlobFileSystemRename extends
           Path path = answer.getArgument(0);
           String leaseId = answer.getArgument(1);
           TracingContext tracingContext = answer.getArgument(2);
-          Assert.assertTrue((srcDir).equalsIgnoreCase(path.toUri().getPath()));
-          deletedCount.incrementAndGet();
+          if (deletedSrcDirSuffix.get()) {
+            Assert.assertTrue(
+                (srcDir + SUFFIX).equalsIgnoreCase(path.toUri().getPath()));
+          } else {
+            Assert.assertTrue(
+                (srcDir).equalsIgnoreCase(path.toUri().getPath()));
+            deletedCount.incrementAndGet();
+          }
           client.deleteBlobPath(path, leaseId, tracingContext);
           return null;
         })


### PR DESCRIPTION
1.  Deletion of directory using producer-consumer design.
2. Parallelism defined by fs.azure.blob.dir.delete.max.thread. Default is 5.
3. Like rename, each delete to have its executorService which will be shutdown once deletion is done.
4. No Lease concept.