### PR TITLE
Acl API's to go to DFS endpoint and throttling metrics collection based on operation type update

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1231,7 +1231,10 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(HttpQueryParams.QUERY_PARAM_ACTION, AbfsHttpConstants.SET_ACCESS_CONTROL);
     appendSASTokenToQuery(path, SASTokenProvider.SET_ACL_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    if (url.toString().contains(WASB_DNS_PREFIX)) {
+      url = changePrefixFromBlobtoDfs(url);
+    }
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.SetAcl,
         this,
@@ -1256,7 +1259,10 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(HttpQueryParams.QUERY_PARAM_UPN, String.valueOf(useUPN));
     appendSASTokenToQuery(path, SASTokenProvider.GET_ACL_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    if (url.toString().contains(WASB_DNS_PREFIX)) {
+      url = changePrefixFromBlobtoDfs(url);
+    }
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetAcl,
         this,
@@ -1283,7 +1289,12 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_ACTION, CHECK_ACCESS);
     abfsUriQueryBuilder.addQuery(QUERY_FS_ACTION, rwx);
     appendSASTokenToQuery(path, SASTokenProvider.CHECK_ACCESS_OPERATION, abfsUriQueryBuilder);
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+
+    URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    if (url.toString().contains(WASB_DNS_PREFIX)) {
+      url = changePrefixFromBlobtoDfs(url);
+    }
+
     AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.CheckAccess, this,
         AbfsHttpConstants.HTTP_METHOD_HEAD, url, createDefaultHeaders());

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientThrottlingIntercept.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientThrottlingIntercept.java
@@ -153,6 +153,7 @@ public final class AbfsClientThrottlingIntercept implements AbfsThrottlingInterc
 
     switch (operationType) {
       case Append:
+      case PutBlock:
         contentLength = abfsHttpOperation.getBytesSent();
         if (contentLength == 0) {
           /*
@@ -170,6 +171,7 @@ public final class AbfsClientThrottlingIntercept implements AbfsThrottlingInterc
         }
         break;
       case ReadFile:
+      case GetBlob:
         String range = abfsHttpOperation.getConnection().getRequestProperty(HttpHeaderConfigurations.RANGE);
         contentLength = getContentLengthIfKnown(range);
         if (contentLength > 0) {
@@ -192,12 +194,14 @@ public final class AbfsClientThrottlingIntercept implements AbfsThrottlingInterc
       AbfsCounters abfsCounters) {
     switch (operationType) {
       case ReadFile:
+      case GetBlob:
         if (readThrottler.suspendIfNecessary()
             && abfsCounters != null) {
           abfsCounters.incrementCounter(AbfsStatistic.READ_THROTTLES, 1);
         }
         break;
       case Append:
+      case PutBlock:
         if (writeThrottler.suspendIfNecessary()
             && abfsCounters != null) {
           abfsCounters.incrementCounter(AbfsStatistic.WRITE_THROTTLES, 1);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStatistics.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsStatistics.java
@@ -104,13 +104,8 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
     assertAbfsStatistics(AbfsStatistic.CALL_CREATE_NON_RECURSIVE, 1, metricMap);
     assertAbfsStatistics(AbfsStatistic.FILES_CREATED, 1, metricMap);
     // Child calls mkdirs for parent in case of blob.
-    if (getPrefixMode(fs) == PrefixMode.BLOB) {
-      assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, 2, metricMap);
-      assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, 2, metricMap);
-    } else {
-      assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, 1, metricMap);
-      assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, 1, metricMap);
-    }
+    assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, 1, metricMap);
+    assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, 1, metricMap);
     assertAbfsStatistics(AbfsStatistic.CALL_GET_FILE_STATUS, 3, metricMap);
 
     //re-initialising Abfs to reset statistic values.
@@ -138,15 +133,9 @@ public class ITestAbfsStatistics extends AbstractAbfsIntegrationTest {
         metricMap);
     assertAbfsStatistics(AbfsStatistic.FILES_CREATED, NUMBER_OF_OPS, metricMap);
     // Child calls mkdirs for parent in case of blob.
-    if (getPrefixMode(fs) == PrefixMode.BLOB) {
-      assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, 2 * NUMBER_OF_OPS,
+    assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, NUMBER_OF_OPS,
               metricMap);
-      assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, 2 * NUMBER_OF_OPS, metricMap);
-    } else {
-      assertAbfsStatistics(AbfsStatistic.DIRECTORIES_CREATED, NUMBER_OF_OPS,
-              metricMap);
-      assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, NUMBER_OF_OPS, metricMap);
-    }
+    assertAbfsStatistics(AbfsStatistic.CALL_MKDIRS, NUMBER_OF_OPS, metricMap);
     assertAbfsStatistics(AbfsStatistic.CALL_GET_FILE_STATUS,
         1 + 2 * NUMBER_OF_OPS, metricMap);
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -120,18 +120,18 @@ public class ITestAzureBlobFileSystemCheckAccess
     }
     checkIfConfigIsSet(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT
             + "." + accountName);
-    Configuration conf = getRawConfiguration();
-    setTestFsConf(FS_AZURE_BLOB_FS_CLIENT_ID,
-            FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_ID);
-    setTestFsConf(FS_AZURE_BLOB_FS_CLIENT_SECRET,
-            FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_SECRET);
+    Configuration conf = Mockito.spy(getRawConfiguration());
+    setTestFsConf1(FS_AZURE_BLOB_FS_CLIENT_ID,
+            FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_ID, conf);
+    setTestFsConf1(FS_AZURE_BLOB_FS_CLIENT_SECRET,
+            FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_SECRET, conf);
     conf.set(FS_AZURE_ACCOUNT_AUTH_TYPE_PROPERTY_NAME, AuthType.OAuth.name());
     conf.set(FS_AZURE_ACCOUNT_TOKEN_PROVIDER_TYPE_PROPERTY_NAME + "."
             + accountName, ClientCredsTokenProvider.class.getName());
     conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
             false);
     FileSystem testUserFsNonHns;
-    testUserFsNonHns = FileSystem.newInstance(getRawConfiguration());
+    testUserFsNonHns = FileSystem.newInstance(conf);
   }
 
   private void setTestFsConf(final String fsConfKey,
@@ -140,6 +140,14 @@ public class ITestAzureBlobFileSystemCheckAccess
     final String confValue = getConfiguration()
         .getString(testFsConfKey, "");
     getRawConfiguration().set(confKeyWithAccountName, confValue);
+  }
+
+  private void setTestFsConf1(final String fsConfKey,
+                             final String testFsConfKey, Configuration conf) {
+    final String confKeyWithAccountName = fsConfKey + "." + getAccountName();
+    final String confValue = getConfiguration()
+            .getString(testFsConfKey, "");
+    conf.set(confKeyWithAccountName, confValue);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
@@ -217,15 +218,14 @@ public class ITestAzureBlobFileSystemCheckAccess
     checkIfConfigIsSet(FS_AZURE_BLOB_FS_CHECKACCESS_TEST_CLIENT_SECRET);
     checkIfConfigIsSet(FS_AZURE_BLOB_FS_CHECKACCESS_TEST_USER_GUID);
 
+    Configuration configuration = Mockito.spy(getFileSystem().getConf());
+    FileSystem testUserFSWithoutNS;
+    testUserFSWithoutNS = FileSystem.newInstance(configuration);
+
     //  When the driver does not know if the account is HNS enabled or not it
     //  makes a server call and fails
     intercept(Exception.class, "\"This request is not authorized to perform this operation using "
             + "this permission.\", 403", this::setTestUserFsNonHNS);
-
-    Configuration configuration = getFileSystem().getConf();
-    configuration.setBoolean(FS_AZURE_ACCOUNT_IS_HNS_ENABLED, false);
-    FileSystem testUserFSWithoutNS;
-    testUserFSWithoutNS = FileSystem.newInstance(configuration);
 
     //  When the driver has already determined if the account is HNS enabled
     //  or not, and as the account is non HNS the AzureBlobFileSystem#access


### PR DESCRIPTION
Make the ACL APi's to go to DFS endpoint.
Also fixed the bug where it was not collecting metrics for operation type being GetBlob and PutBlock
