### PR TITLE
RenameDir and DeleteDir on blob to push number of blobs operated on last API call.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -926,18 +926,18 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
           fileSystemId, FSOperationType.LISTSTATUS, true, tracingHeaderFormat,
           listener);
-      FileStatus[] result = abfsStore.listStatus(qualifiedPath, tracingContext);
+      FileStatus[] result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
       if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
           == PrefixMode.BLOB) {
         FileStatus renamePendingFileStatus
-            = abfsStore.getRenamePendingFileStatus(result);
+            = getAbfsStore().getRenamePendingFileStatus(result);
         if (renamePendingFileStatus != null) {
           RenameAtomicityUtils renameAtomicityUtils =
               new RenameAtomicityUtils(this,
                   renamePendingFileStatus.getPath(),
-                  abfsStore.getRedoRenameInvocation(tracingContext));
+                  getAbfsStore().getRedoRenameInvocation(tracingContext));
           renameAtomicityUtils.cleanup(renamePendingFileStatus.getPath());
-          result = abfsStore.listStatus(qualifiedPath, tracingContext);
+          result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
         }
       }
       return result;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1048,7 +1048,7 @@ public class AzureBlobFileSystem extends FileSystem
   @Override
   public FileStatus getFileStatus(final Path f) throws IOException {
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
-          fileSystemId, FSOperationType.GET_FILESTATUS, tracingHeaderFormat,
+          fileSystemId, FSOperationType.GET_FILESTATUS, true, tracingHeaderFormat,
           listener);
       return getFileStatus(f, tracingContext);
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1070,17 +1070,17 @@ public class AzureBlobFileSystem extends FileSystem
          * Get File Status over Blob Endpoint will Have an additional call
          * to check if directory is implicit.
          */
-        fileStatus = abfsStore.getFileStatus(qualifiedPath,
+        fileStatus = getAbfsStore().getFileStatus(qualifiedPath,
             tracingContext, useBlobEndpoint);
         if (getAbfsStore().getPrefixMode() == PrefixMode.BLOB
                 && fileStatus != null && fileStatus.isDirectory()
-          && abfsStore.isAtomicRenameKey(fileStatus.getPath().toUri().getPath())
-          && abfsStore.getRenamePendingFileStatusInDirectory(fileStatus,
+          && getAbfsStore().isAtomicRenameKey(fileStatus.getPath().toUri().getPath())
+          && getAbfsStore().getRenamePendingFileStatusInDirectory(fileStatus,
               tracingContext)) {
         RenameAtomicityUtils renameAtomicityUtils = new RenameAtomicityUtils(
             this,
             new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
-            abfsStore.getRedoRenameInvocation(tracingContext));
+            getAbfsStore().getRedoRenameInvocation(tracingContext));
         renameAtomicityUtils.cleanup(
             new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
         throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -871,7 +871,7 @@ public class AzureBlobFileSystem extends FileSystem
     statIncrement(CALL_DELETE);
     Path qualifiedPath = makeQualified(f);
     TracingContext tracingContext = new TracingContext(clientCorrelationId,
-            fileSystemId, FSOperationType.DELETE, tracingHeaderFormat,
+            fileSystemId, FSOperationType.DELETE, true, tracingHeaderFormat,
             listener);
 
     if (shouldRedirect(FSOperationType.DELETE, tracingContext)) {
@@ -933,9 +933,8 @@ public class AzureBlobFileSystem extends FileSystem
             = getAbfsStore().getRenamePendingFileStatus(result);
         if (renamePendingFileStatus != null) {
           RenameAtomicityUtils renameAtomicityUtils =
-              new RenameAtomicityUtils(this,
-                  renamePendingFileStatus.getPath(),
-                  getAbfsStore().getRedoRenameInvocation(tracingContext));
+              getRenameAtomicityUtilsForRedo(renamePendingFileStatus.getPath(),
+                  tracingContext);
           renameAtomicityUtils.cleanup(renamePendingFileStatus.getPath());
           result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
         }
@@ -945,6 +944,13 @@ public class AzureBlobFileSystem extends FileSystem
       checkException(f, ex);
       return null;
     }
+  }
+
+  RenameAtomicityUtils getRenameAtomicityUtilsForRedo(final Path renamePendingFileStatus,
+      final TracingContext tracingContext) throws IOException {
+    return new RenameAtomicityUtils(this,
+        renamePendingFileStatus,
+        getAbfsStore().getRedoRenameInvocation(tracingContext));
   }
 
   /**
@@ -1077,10 +1083,9 @@ public class AzureBlobFileSystem extends FileSystem
           && getAbfsStore().isAtomicRenameKey(fileStatus.getPath().toUri().getPath())
           && getAbfsStore().getRenamePendingFileStatusInDirectory(fileStatus,
               tracingContext)) {
-        RenameAtomicityUtils renameAtomicityUtils = new RenameAtomicityUtils(
-            this,
+        RenameAtomicityUtils renameAtomicityUtils = getRenameAtomicityUtilsForRedo(
             new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
-            getAbfsStore().getRedoRenameInvocation(tracingContext));
+            tracingContext);
         renameAtomicityUtils.cleanup(
             new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
         throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -195,4 +195,7 @@ public class TracingContext {
     return header;
   }
 
+  public String getPrimaryRequestId() {
+    return primaryRequestId;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -78,7 +78,7 @@ public class TracingContext {
   public static final int MAX_CLIENT_CORRELATION_ID_LENGTH = 72;
   public static final String CLIENT_CORRELATION_ID_PATTERN = "[a-zA-Z0-9-]*";
 
-  private Integer renameBlobCount = null;
+  private Integer operatedBlobCount = null;
 
   /**
    * Initialize TracingContext
@@ -189,8 +189,8 @@ public class TracingContext {
               + getPrimaryRequestIdForHeader(retryCount > 0) + ":" + streamID
               + ":" + opType + ":" + retryCount;
       header = addFailureReasons(header, previousFailure) + ":" + fallbackDFSAppend;
-      if (renameBlobCount != null) {
-        header += (":" + renameBlobCount);
+      if (operatedBlobCount != null) {
+        header += (":" + operatedBlobCount);
       }
       break;
     case TWO_ID_FORMAT:
@@ -250,7 +250,7 @@ public class TracingContext {
     return primaryRequestId;
   }
 
-  public void setRenameBlobCount(Integer count) {
-    renameBlobCount = count;
+  public void setOperatedBlobCount(Integer count) {
+    operatedBlobCount = count;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -68,6 +68,8 @@ public class TracingContext {
   public static final int MAX_CLIENT_CORRELATION_ID_LENGTH = 72;
   public static final String CLIENT_CORRELATION_ID_PATTERN = "[a-zA-Z0-9-]*";
 
+  private Integer renameBlobCount = null;
+
   /**
    * Initialize TracingContext
    * @param clientCorrelationID Provided over config by client
@@ -174,6 +176,9 @@ public class TracingContext {
           clientCorrelationID + ":" + clientRequestId + ":" + fileSystemID + ":"
               + primaryRequestId + ":" + streamID + ":" + opType + ":"
               + retryCount + ":" + fallbackDFSAppend;
+      if (renameBlobCount != null) {
+        header += (":" + renameBlobCount);
+      }
       break;
     case TWO_ID_FORMAT:
       header = clientCorrelationID + ":" + clientRequestId;
@@ -197,5 +202,9 @@ public class TracingContext {
 
   public String getPrimaryRequestId() {
     return primaryRequestId;
+  }
+
+  public void setRenameBlobCount(Integer count) {
+    renameBlobCount = count;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -253,4 +253,8 @@ public class TracingContext {
   public void setOperatedBlobCount(Integer count) {
     operatedBlobCount = count;
   }
+
+  public Integer getOperatedBlobCount() {
+    return operatedBlobCount;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -257,4 +257,8 @@ public class TracingContext {
   public Integer getOperatedBlobCount() {
     return operatedBlobCount;
   }
+
+  public FSOperationType getOpType() {
+    return opType;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -459,6 +459,12 @@ public class ITestAzureBlobFileSystemDelete extends
     fs.delete(new Path(dirPathStr), true);
   }
 
+  /**
+   * Test to assert that the CID in src marker delete contains the
+   * total number of blobs operated in the delete directory.
+   * Also, to assert that all operations in the delete-directory flow have same
+   * primaryId and opType.
+   */
   @Test
   public void testIfTracingContextPrimaryIdIsSameInAllTheStepsOfBlobDelete()
       throws Exception {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -414,4 +414,11 @@ public class ITestAzureBlobFileSystemDelete extends
     Long newLmt = fs.getFileStatus(new Path("/dir1")).getModificationTime();
     Assertions.assertThat(lmt).isEqualTo(newLmt);
   }
+
+  @Test
+  public void testDeleteEmitDeletionCountInClientRequestId() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    Assume.assumeTrue(getPrefixMode(fs) == PrefixMode.BLOB);
+
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.services.ITestAbfsClient;
-import org.apache.hadoop.fs.azurebfs.services.RenameAtomicityUtils;
 import org.apache.hadoop.fs.azurebfs.services.TestAbfsPerfTracker;
 import org.apache.hadoop.fs.azurebfs.utils.TestMockHelpers;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -417,8 +417,44 @@ public class ITestAzureBlobFileSystemDelete extends
 
   @Test
   public void testDeleteEmitDeletionCountInClientRequestId() throws Exception {
-    AzureBlobFileSystem fs = getFileSystem();
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
     Assume.assumeTrue(getPrefixMode(fs) == PrefixMode.BLOB);
+    String dirPathStr = "/testDir/dir1";
+    fs.mkdirs(new Path(dirPathStr));
+    ExecutorService executorService = Executors.newFixedThreadPool(5);
+    List<Future> futures = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      final int iter = i;
+      Future future = executorService.submit(() -> {
+        return fs.create(new Path("/testDir/dir1/file" + iter));
+      });
+      futures.add(future);
+    }
 
+    for (Future future : futures) {
+      future.get();
+    }
+    executorService.shutdown();
+
+
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    AbfsClient client = Mockito.spy(store.getClient());
+    store.setClient(client);
+
+    Mockito.doAnswer(answer -> {
+          if (dirPathStr.equalsIgnoreCase(
+              ((Path) answer.getArgument(0)).toUri().getPath())) {
+            TracingContext tracingContext = answer.getArgument(2);
+            Assertions.assertThat(tracingContext.getOperatedBlobCount())
+                .isEqualTo(11);
+          }
+          return answer.callRealMethod();
+        })
+        .when(client)
+        .deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class),
+            Mockito.any(TracingContext.class));
+
+    fs.delete(new Path(dirPathStr), true);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2106,9 +2106,30 @@ public class ITestAzureBlobFileSystemRename extends
         Mockito.mock(TracingContext.class));
     String leaseId = op.getResult()
         .getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
+    Map<String, String> pathLeaseIdMap = new HashMap<>();
+    Mockito.doAnswer(answer -> {
+          AbfsRestOperation abfsRestOperation
+              = (AbfsRestOperation) answer.callRealMethod();
+          pathLeaseIdMap.put(answer.getArgument(0),
+              abfsRestOperation.getResult().getResponseHeader(X_MS_LEASE_ID));
+          return abfsRestOperation;
+        })
+        .when(client)
+        .acquireBlobLease(Mockito.anyString(), Mockito.anyInt(),
+            Mockito.any(TracingContext.class));
+
     intercept(Exception.class, () -> {
       fs.rename(new Path("/hbase/testDir"), new Path("/hbase/testDir2"));
     });
+
+    for (Map.Entry<String, String> entry : pathLeaseIdMap.entrySet()) {
+      try {
+        client.releaseBlobLease(entry.getKey(), entry.getValue(),
+            Mockito.mock(TracingContext.class));
+      } catch (Exception e) {
+
+      }
+    }
     client.releaseBlobLease("/hbase/testDir/file5", leaseId,
         Mockito.mock(TracingContext.class));
 
@@ -2170,11 +2191,34 @@ public class ITestAzureBlobFileSystemRename extends
         Mockito.mock(TracingContext.class));
     String leaseId = op.getResult()
         .getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
+
+    Map<String, String> pathLeaseIdMap = new HashMap<>();
+    Mockito.doAnswer(answer -> {
+          AbfsRestOperation abfsRestOperation
+              = (AbfsRestOperation) answer.callRealMethod();
+          pathLeaseIdMap.put(answer.getArgument(0),
+              abfsRestOperation.getResult().getResponseHeader(X_MS_LEASE_ID));
+          return abfsRestOperation;
+        })
+        .when(client)
+        .acquireBlobLease(Mockito.anyString(), Mockito.anyInt(),
+            Mockito.any(TracingContext.class));
+
     intercept(Exception.class, () -> {
       fs.rename(new Path("/hbase/testDir"), new Path("/hbase/testDir2"));
     });
+
+    for (Map.Entry<String, String> entry : pathLeaseIdMap.entrySet()) {
+      try {
+        client.releaseBlobLease(entry.getKey(), entry.getValue(),
+            Mockito.mock(TracingContext.class));
+      } catch (Exception e) {
+
+      }
+    }
     client.releaseBlobLease("/hbase/testDir/file5", leaseId,
         Mockito.mock(TracingContext.class));
+
 
     TracingContext[] tracingContextCreatedInFsListStatus
         = new TracingContext[1];

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2035,6 +2035,12 @@ public class ITestAzureBlobFileSystemRename extends
     }
   }
 
+  /**
+   * Test to assert that the CID in src marker blob copy and delete contains the
+   * total number of blobs operated in the rename directory.
+   * Also, to assert that all operations in the rename-directory flow have same
+   * primaryId and opType.
+   */
   @Test
   public void testRenameSrcDirDeleteEmitDeletionCountInClientRequestId() throws Exception {
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
@@ -2078,6 +2084,12 @@ public class ITestAzureBlobFileSystemRename extends
     fs.rename(new Path(dirPathStr), new Path("/dst/"));
   }
 
+  /**
+   * Test to assert that the rename resume from FileStatus uses the same
+   * {@link TracingContext} object used by the initial ListStatus call.
+   * Also assert that last rename's copy and delete API call would push count
+   * of blobs operated in resume flow in clientRequestId.
+   */
   @Test
   public void testBlobRenameResumeWithListStatus() throws Exception {
     assumeNonHnsAccountBlobEndpoint(getFileSystem());
@@ -2169,6 +2181,12 @@ public class ITestAzureBlobFileSystemRename extends
     Assertions.assertThat(copied.get()).isGreaterThan(0);
   }
 
+  /**
+   * Test to assert that the rename resume from FileStatus uses the same
+   * {@link TracingContext} object used by the initial GetFileStatus call.
+   * Also assert that last rename's copy and delete API call would push count
+   * of blobs operated in resume flow in clientRequestId.
+   */
   @Test
   public void testBlobRenameResumeWithGetFileStatus() throws Exception {
     assumeNonHnsAccountBlobEndpoint(getFileSystem());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1683,9 +1683,10 @@ public class ITestAzureBlobFileSystemRename extends
     Mockito.doAnswer(answer -> {
           final TracingContext context = answer.getArgument(3);
           Mockito.doAnswer(listAnswer -> {
-                TracingContext listContext = listAnswer.getArgument(3);
+                TracingContext listContext = listAnswer.getArgument(4);
                 Assert.assertEquals(listContext.getPrimaryRequestId(),
                     context.getPrimaryRequestId());
+                Assert.assertTrue(context.getOpType().equals(listContext.getOpType()));
                 return listAnswer.callRealMethod();
               })
               .when(client)
@@ -1694,9 +1695,10 @@ public class ITestAzureBlobFileSystemRename extends
                   Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
 
           Mockito.doAnswer(copyAnswer -> {
-                TracingContext copyContext = copyAnswer.getArgument(2);
+                TracingContext copyContext = copyAnswer.getArgument(3);
                 Assert.assertEquals(copyContext.getPrimaryRequestId(),
                     context.getPrimaryRequestId());
+                Assert.assertTrue(context.getOpType().equals(copyContext.getOpType()));
                 return copyAnswer.callRealMethod();
               })
               .when(client)
@@ -1704,9 +1706,10 @@ public class ITestAzureBlobFileSystemRename extends
                   Mockito.any(TracingContext.class));
 
           Mockito.doAnswer(deleteAnswer -> {
-                TracingContext deleteContext = deleteAnswer.getArgument(1);
+                TracingContext deleteContext = deleteAnswer.getArgument(2);
                 Assert.assertEquals(deleteContext.getPrimaryRequestId(),
                     context.getPrimaryRequestId());
+                Assert.assertTrue(context.getOpType().equals(deleteContext.getOpType()));
                 return deleteAnswer.callRealMethod();
               })
               .when(client)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -45,8 +45,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -44,6 +44,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -2075,5 +2077,69 @@ public class ITestAzureBlobFileSystemRename extends
             Mockito.any(TracingContext.class));
 
     fs.rename(new Path(dirPathStr), new Path("/dst/"));
+  }
+
+  @Test
+  public void testBlobRenameResumeWithListStatus() throws Exception {
+    assumeNonHnsAccountBlobEndpoint(getFileSystem());
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+
+    fs.mkdirs(new Path("/hbase/testDir"));
+    ExecutorService executorService = Executors.newFixedThreadPool(5);
+    List<Future> futures = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      final int iter = i;
+      futures.add(executorService.submit(
+          () -> fs.create(new Path("/hbase/testDir/file" + iter))));
+    }
+
+    for (Future future : futures) {
+      future.get();
+    }
+
+    AbfsClient client = Mockito.spy(fs.getAbfsClient());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    store.setClient(client);
+
+    AbfsRestOperation op = client.acquireBlobLease("/hbase/testDir/file5", -1,
+        Mockito.mock(TracingContext.class));
+    String leaseId = op.getResult()
+        .getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
+    intercept(Exception.class, () -> {
+      fs.rename(new Path("/hbase/testDir"), new Path("/hbase/testDir2"));
+    });
+    client.releaseBlobLease("/hbase/testDir/file5", leaseId,
+        Mockito.mock(TracingContext.class));
+
+    TracingContext[] tracingContextCreatedInFsListStatus
+        = new TracingContext[1];
+    Mockito.doAnswer(answer -> {
+          tracingContextCreatedInFsListStatus[0] = answer.getArgument(1);
+          return answer.callRealMethod();
+        })
+        .when(store)
+        .listStatus(Mockito.any(Path.class), Mockito.any(TracingContext.class));
+
+    AtomicInteger copied = new AtomicInteger(0);
+    Mockito.doAnswer(answer -> {
+          copied.incrementAndGet();
+          TracingContext tracingContext = answer.getArgument(3);
+          Assertions.assertThat(tracingContext)
+              .isEqualTo(tracingContextCreatedInFsListStatus[0]);
+          Path path = answer.getArgument(0);
+          if ("/hbase/testDir".equalsIgnoreCase(path.toUri().getPath())) {
+            Assertions.assertThat(tracingContext.getOperatedBlobCount())
+                .isEqualTo(copied.get());
+          }
+          return answer.callRealMethod();
+        })
+        .when(store)
+        .copyBlob(Mockito.any(Path.class), Mockito.any(Path.class),
+            Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+
+    fs.listStatus(new Path("/hbase"));
+    Assertions.assertThat(fs.exists(new Path("/hbase/testDir2"))).isTrue();
+    Assertions.assertThat(copied.get()).isGreaterThan(0);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1577,8 +1577,8 @@ public class ITestAzureBlobFileSystemRename extends
                   Mockito.any(TracingContext.class));
 
           Mockito.doAnswer(copyAnswer -> {
-                TracingContext listContext = copyAnswer.getArgument(2);
-                Assert.assertEquals(listContext.getPrimaryRequestId(),
+                TracingContext copyContext = copyAnswer.getArgument(2);
+                Assert.assertEquals(copyContext.getPrimaryRequestId(),
                     context.getPrimaryRequestId());
                 return copyAnswer.callRealMethod();
               })
@@ -1587,8 +1587,8 @@ public class ITestAzureBlobFileSystemRename extends
                   Mockito.any(TracingContext.class));
 
           Mockito.doAnswer(deleteAnswer -> {
-                TracingContext listContext = deleteAnswer.getArgument(1);
-                Assert.assertEquals(listContext.getPrimaryRequestId(),
+                TracingContext deleteContext = deleteAnswer.getArgument(1);
+                Assert.assertEquals(deleteContext.getPrimaryRequestId(),
                     context.getPrimaryRequestId());
                 return deleteAnswer.callRealMethod();
               })

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/utils/TracingHeaderValidator.java
@@ -38,10 +38,16 @@ public class TracingHeaderValidator implements Listener {
   private TracingHeaderFormat format;
 
   private static final String GUID_PATTERN = "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$";
+  private Integer operatedBlobCount = null;
+
+  private Boolean disableValidation = false;
 
   @Override
   public void callTracingHeaderValidator(String tracingContextHeader,
       TracingHeaderFormat format) {
+    if (disableValidation) {
+      return;
+    }
     this.format = format;
     validateTracingHeader(tracingContextHeader);
   }
@@ -52,6 +58,9 @@ public class TracingHeaderValidator implements Listener {
         clientCorrelationId, fileSystemId, operation, needsPrimaryRequestId,
         retryNum, streamID);
     tracingHeaderValidator.primaryRequestId = primaryRequestId;
+    if (disableValidation) {
+      tracingHeaderValidator.setDisableValidation(true);
+    }
     return tracingHeaderValidator;
   }
 
@@ -78,6 +87,13 @@ public class TracingHeaderValidator implements Listener {
     if (format != TracingHeaderFormat.ALL_ID_FORMAT) {
       return;
     }
+    if (idList.length >= 9) {
+      if (operatedBlobCount != null) {
+        Assertions.assertThat(Integer.parseInt(idList[8]))
+            .describedAs("OperatedBlobCount is incorrect")
+            .isEqualTo(operatedBlobCount);
+      }
+    }
     if (!primaryRequestId.isEmpty() && !idList[3].isEmpty()) {
       Assertions.assertThat(idList[3])
           .describedAs("PrimaryReqID should be common for these requests")
@@ -93,7 +109,8 @@ public class TracingHeaderValidator implements Listener {
   private void validateBasicFormat(String[] idList) {
     if (format == TracingHeaderFormat.ALL_ID_FORMAT) {
       Assertions.assertThat(idList)
-          .describedAs("header should have 8 elements").hasSize(8);
+          .describedAs("header should have 8 or 9 elements")
+          .hasSizeBetween(8, 9);
     } else if (format == TracingHeaderFormat.TWO_ID_FORMAT) {
       Assertions.assertThat(idList)
           .describedAs("header should have 2 elements").hasSize(2);
@@ -151,5 +168,13 @@ public class TracingHeaderValidator implements Listener {
   @Override
   public void updatePrimaryRequestID(String primaryRequestId) {
     this.primaryRequestId = primaryRequestId;
+  }
+
+  public void setOperatedBlobCount(Integer operatedBlobCount) {
+    this.operatedBlobCount = operatedBlobCount;
+  }
+
+  public void setDisableValidation(Boolean disableValidation) {
+    this.disableValidation = disableValidation;
   }
 }


### PR DESCRIPTION
PR Details:
1. After a successful rename, last copy and delete will have the number of blobs operated.
2. When rename resumed from listStatus, all operation for copy / delete will have same primaryId of the ListStatus and have optpye LS.. Similarly in getFileStatus, it will have GF.


Example of final CID in listStatus:
```
,cid=:aba4021b-81fe-4442-bb11-98222d6bd2e1:53441220-a477-48e6-9f84-b1c9d9b5dc12:dae069a2-06d8-4697-a78b-902f6f9e726c::LS:0:B:2
```

Example in getFileStatus:
```
cid=:3b244e98-aaf9-456d-86c2-480824509694:3b9df2a2-bcde-44d7-b5f2-7d65803f30f4:e76becea-4dd5-4d0c-8362-d7a78a996267::GF:0:B:2
```

------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 772, Failures: 0, Errors: 1, Skipped: 182
[INFO] Results:
[INFO]
[WARNING] Tests run: 278, Failures: 0, Errors: 0, Skipped: 44

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 140, Failures: 1, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:276->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=28).
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 772, Failures: 1, Errors: 1, Skipped: 182
[INFO] Results:
[INFO]
[WARNING] Tests run: 278, Failures: 0, Errors: 0, Skipped: 44

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsStatistics.testCreateStatistics:108->AbstractAbfsIntegrationTest.assertAbfsStatistics:510->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 Mismatch in directories_created expected:<2> but was:<1>
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:276->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=140).
[INFO]
[ERROR] Tests run: 772, Failures: 2, Errors: 0, Skipped: 276
[INFO] Results:
[INFO]
[WARNING] Tests run: 278, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsStatistics.testCreateStatistics:108->AbstractAbfsIntegrationTest.assertAbfsStatistics:510->Assert.assertEquals:647->Assert.failNotEquals:835->Assert.fail:89 Mismatch in directories_created expected:<2> but was:<1>
[INFO]
[ERROR] Tests run: 772, Failures: 1, Errors: 0, Skipped: 276
[INFO] Results:
[INFO]
[WARNING] Tests run: 278, Failures: 0, Errors: 0, Skipped: 45

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:371 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 772, Failures: 0, Errors: 1, Skipped: 182
[INFO] Results:
[INFO]
[WARNING] Tests run: 278, Failures: 0, Errors: 0, Skipped: 44



```
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit 460fd867e1ab93693445f56ba2c331bcc4c9f953 (HEAD -> ABFS_3.3.2_dev_rename_tc, origin/ABFS_3.3.2_dev_rename_tc)
Author: Pranav Saxena <>
Date:   Tue Jun 27 22:26:47 2023 -0700

    concurrency in lease release

```