### PR TITLE
Adding Activity Id(rID) in Exception Message

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,21 +84,22 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rid: %4$s",
-              abfsHttpOperation.getStatusDescription(),
-              abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getMaskedUrl(),
-              abfsHttpOperation.getRequestId());
+          "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
+          abfsHttpOperation.getStatusDescription(),
+          abfsHttpOperation.getStatusCode(),
+          abfsHttpOperation.getMaskedUrl(),
+          abfsHttpOperation.getRequestId());
     }
 
     return String.format(
-            "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, %5$s, \"%6$s\"",
-            abfsHttpOperation.getStatusDescription(),
-            abfsHttpOperation.getStatusCode(),
-            abfsHttpOperation.getMethod(),
-            abfsHttpOperation.getMaskedUrl(),
-            abfsHttpOperation.getStorageErrorCode(),
-            // Remove break line to ensure the request id and timestamp can be shown in console.
-            abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));
+        "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
+        abfsHttpOperation.getStatusDescription(),
+        abfsHttpOperation.getStatusCode(),
+        abfsHttpOperation.getMethod(),
+        abfsHttpOperation.getMaskedUrl(),
+        abfsHttpOperation.getRequestId(),
+        abfsHttpOperation.getStorageErrorCode(),
+        // Remove break line to ensure the request id and timestamp can be shown in console.
+        abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,15 +84,14 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-      "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
+              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getMaskedUrl(),
-              abfsHttpOperation.getRequestId());
+              abfsHttpOperation.getMaskedUrl());
     }
 
     return String.format(
-    "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
+            "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
             abfsHttpOperation.getStatusDescription(),
             abfsHttpOperation.getStatusCode(),
             abfsHttpOperation.getMethod(),

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -85,21 +85,21 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
           "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
-          abfsHttpOperation.getStatusDescription(),
-          abfsHttpOperation.getStatusCode(),
-          abfsHttpOperation.getMaskedUrl(),
-          abfsHttpOperation.getRequestId());
+              abfsHttpOperation.getStatusDescription(),
+              abfsHttpOperation.getStatusCode(),
+              abfsHttpOperation.getMaskedUrl(),
+              abfsHttpOperation.getRequestId());
     }
 
     return String.format(
         "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
-        abfsHttpOperation.getStatusDescription(),
-        abfsHttpOperation.getStatusCode(),
-        abfsHttpOperation.getMethod(),
-        abfsHttpOperation.getMaskedUrl(),
-        abfsHttpOperation.getRequestId(),
-        abfsHttpOperation.getStorageErrorCode(),
-        // Remove break line to ensure the request id and timestamp can be shown in console.
-        abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));
+            abfsHttpOperation.getStatusDescription(),
+            abfsHttpOperation.getStatusCode(),
+            abfsHttpOperation.getMethod(),
+            abfsHttpOperation.getMaskedUrl(),
+            abfsHttpOperation.getRequestId(),
+            abfsHttpOperation.getStorageErrorCode(),
+            // Remove break line to ensure the request id and timestamp can be shown in console.
+            abfsHttpOperation.getStorageErrorMessage().replaceAll("\\n", " "));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,10 +84,11 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s",
+              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, %4$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getMaskedUrl());
+              abfsHttpOperation.getMaskedUrl(),
+              abfsHttpOperation.getRequestId());
     }
 
     return String.format(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,10 +84,11 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s",
+              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rid: %4$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
-              abfsHttpOperation.getMaskedUrl());
+              abfsHttpOperation.getMaskedUrl(),
+              abfsHttpOperation.getRequestId());
     }
 
     return String.format(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,7 +84,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, %4$s",
+              "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
               abfsHttpOperation.getMaskedUrl(),

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/contracts/exceptions/AbfsRestOperationException.java
@@ -84,7 +84,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     // HEAD request response doesn't have StorageErrorCode, StorageErrorMessage.
     if (abfsHttpOperation.getMethod().equals("HEAD")) {
       return String.format(
-          "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
+      "Operation failed: \"%1$s\", %2$s, HEAD, %3$s, rId: %4$s",
               abfsHttpOperation.getStatusDescription(),
               abfsHttpOperation.getStatusCode(),
               abfsHttpOperation.getMaskedUrl(),
@@ -92,7 +92,7 @@ public class AbfsRestOperationException extends AzureBlobFileSystemException {
     }
 
     return String.format(
-        "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
+    "Operation failed: \"%1$s\", %2$s, %3$s, %4$s, rId: %5$s, %6$s, \"%7$s\"",
             abfsHttpOperation.getStatusDescription(),
             abfsHttpOperation.getStatusCode(),
             abfsHttpOperation.getMethod(),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -72,7 +72,8 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       String errorMessage = ex.getLocalizedMessage();
       String[] errorFields = errorMessage.split(",");
 
-      Assert.assertEquals(4, errorFields.length);
+      // Expected Fields are: Message, StatusCode, Method, URL, ActivityId(rId)
+      Assert.assertEquals(5, errorFields.length);
       // Check status message, status code, HTTP Request Type and URL.
       if (useBlobEndpoint) {
         Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
@@ -83,6 +84,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       Assert.assertEquals("404", errorFields[1].trim());
       Assert.assertEquals("HEAD", errorFields[2].trim());
       Assert.assertTrue(errorFields[3].trim().startsWith("http"));
+      Assert.assertTrue(errorFields[4].trim().startsWith("rid:"));
     }
 
     try {
@@ -109,7 +111,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
         Assert.assertTrue(errorFields[5].contains("RequestId")
                 && errorFields[5].contains("Time"));
       } else {
-        Assert.assertEquals(4, errorFields.length);
+        Assert.assertEquals(5, errorFields.length);
         // Check status message, status code, HTTP Request Type and URL.
         if (useBlobEndpoint) {
           Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
@@ -120,6 +122,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
         Assert.assertEquals("404", errorFields[1].trim());
         Assert.assertEquals("HEAD", errorFields[2].trim());
         Assert.assertTrue(errorFields[3].trim().startsWith("http"));
+        Assert.assertTrue(errorFields[4].trim().startsWith("rid:"));
       }
     }
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.azurebfs;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Hashtable;
 
 import org.apache.hadoop.fs.azurebfs.services.OperativeEndpoint;
 import org.assertj.core.api.Assertions;
@@ -34,6 +35,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import org.mockito.Mockito;
 
@@ -84,7 +86,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       Assert.assertEquals("404", errorFields[1].trim());
       Assert.assertEquals("HEAD", errorFields[2].trim());
       Assert.assertTrue(errorFields[3].trim().startsWith("http"));
-      Assert.assertTrue(errorFields[4].trim().startsWith("rid:"));
+      Assert.assertTrue(errorFields[4].trim().startsWith("rId:"));
     }
 
     try {
@@ -95,7 +97,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       String[] errorFields = errorMessage.split(",");
       // Flow is different for listStatusIterator being enabled or not.
       if (!getAbfsStore(fs).getAbfsConfiguration().enableAbfsListIterator()) {
-        Assert.assertEquals(6, errorFields.length);
+        Assert.assertEquals(7, errorFields.length);
         // Check status message, status code, HTTP Request Type and URL.
         if (useBlobEndpoint) {
           Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
@@ -106,6 +108,7 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
         Assert.assertEquals("404", errorFields[1].trim());
         Assert.assertEquals("GET", errorFields[2].trim());
         Assert.assertTrue(errorFields[3].trim().startsWith("http"));
+        Assert.assertTrue(errorFields[4].trim().startsWith("rId:"));
         // Check storage error code and storage error message.
         Assert.assertEquals("PathNotFound", errorFields[4].trim());
         Assert.assertTrue(errorFields[5].contains("RequestId")
@@ -122,8 +125,31 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
         Assert.assertEquals("404", errorFields[1].trim());
         Assert.assertEquals("HEAD", errorFields[2].trim());
         Assert.assertTrue(errorFields[3].trim().startsWith("http"));
-        Assert.assertTrue(errorFields[4].trim().startsWith("rid:"));
+        Assert.assertTrue(errorFields[4].trim().startsWith("rId:"));
       }
+    }
+    // Check Exception Format For Put Method
+    try {
+      Hashtable<String, String> metadata = new Hashtable<>();
+      metadata.put("hi", "hello");
+      fs.getAbfsStore().setBlobMetadata(fs.makeQualified(nonExistedFilePath1), metadata, Mockito.mock(
+          TracingContext.class));
+    } catch (AbfsRestOperationException ex) {
+      String errorMessage = ex.getLocalizedMessage();
+      String[] errorFields = errorMessage.split(",");
+
+      Assert.assertEquals(7, errorFields.length);
+      // Check status message, status code, HTTP Request Type and URL.
+      if (useBlobEndpoint) {
+        Assert.assertEquals("Operation failed: \"The specified blob does not exist.\"", errorFields[0].trim());
+      }
+      else {
+        Assert.assertEquals("Operation failed: \"The specified path does not exist.\"", errorFields[0].trim());
+      }
+      Assert.assertEquals("404", errorFields[1].trim());
+      Assert.assertEquals("PUT", errorFields[2].trim());
+      Assert.assertTrue(errorFields[3].trim().startsWith("http"));
+      Assert.assertTrue(errorFields[4].trim().startsWith("rId:"));
     }
   }
 


### PR DESCRIPTION
Adding Activity Id (rId) in the exception message that is thrown to the user in case of server call failures.
This rId is a part of response from server and will help in debugging issues.

Sample Exception:
Operation failed: "The specified blob does not exist.", 404, HEAD, https://anujtestfns.blob.core.windows.net/abfs-testcontainer-4162c570-a45c-4263-9e90-0de6aaf67829/user/snvijaya/nonExistedPath1?timeout=90, rId: 576d2e66-e01e-001f-1d67-aac6f7000000

Operation failed: "The specified blob does not exist.", 404, PUT, https://anujtestfns.blob.core.windows.net/abfs-testcontainer-4162c570-a45c-4263-9e90-0de6aaf67829/user/snvijaya/nonExistedPath1?comp=metadata&timeout=90, rId: 1fd3ac40-001e-0038-7267-aad133000000, , ""