### PR TITLE
Mkdirs called from delete have to take care of the ingress config

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1020,7 +1020,7 @@ public class AzureBlobFileSystem extends FileSystem
               listener);
       abfsStore.createDirectory(qualifiedPath, statistics,
               permission == null ? FsPermission.getDirDefault() : permission,
-              FsPermission.getUMask(getConf()), tracingContext);
+              FsPermission.getUMask(getConf()), true, tracingContext);
       statIncrement(DIRECTORIES_CREATED);
       return true;
     } catch (AzureBlobFileSystemException ex) {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -986,7 +986,7 @@ public class ITestAzureBlobFileSystemCreate extends
     Mockito.doAnswer(answer -> {
           AbfsRestOperation op = (AbfsRestOperation) answer.callRealMethod();
           createCalled.set(true);
-          while (!parallelRenameDone.get()) ;
+          while (!parallelRenameDone.get());
           return op;
         })
         .when(client)
@@ -1042,7 +1042,7 @@ public class ITestAzureBlobFileSystemCreate extends
     Mockito.doAnswer(answer -> {
           AbfsRestOperation op = (AbfsRestOperation) answer.callRealMethod();
           createCalled.set(true);
-          while (!parallelRenameDone.get()) ;
+          while (!parallelRenameDone.get());
           return op;
         })
         .when(client)

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -983,6 +983,18 @@ public class ITestAzureBlobFileSystemCreate extends
     }).when(client).createPathBlob(Mockito.anyString(), Mockito.anyBoolean(),
         Mockito.anyBoolean(), Mockito.nullable(HashMap.class), Mockito.nullable(String.class), Mockito.nullable(TracingContext.class));
 
+    Mockito.doAnswer(answer -> {
+          AbfsRestOperation op = (AbfsRestOperation) answer.callRealMethod();
+          createCalled.set(true);
+          while (!parallelRenameDone.get()) ;
+          return op;
+        })
+        .when(client)
+        .createPath(Mockito.anyString(), Mockito.anyBoolean(),
+            Mockito.anyBoolean(), Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.anyBoolean(),
+            Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+
     new Thread(() -> {
       try {
         while(!createCalled.get());
@@ -1026,6 +1038,18 @@ public class ITestAzureBlobFileSystemCreate extends
       return op;
     }).when(client).createPathBlob(Mockito.anyString(), Mockito.anyBoolean(),
         Mockito.anyBoolean(), Mockito.nullable(HashMap.class), Mockito.nullable(String.class), Mockito.nullable(TracingContext.class));
+
+    Mockito.doAnswer(answer -> {
+          AbfsRestOperation op = (AbfsRestOperation) answer.callRealMethod();
+          createCalled.set(true);
+          while (!parallelRenameDone.get()) ;
+          return op;
+        })
+        .when(client)
+        .createPath(Mockito.anyString(), Mockito.anyBoolean(),
+            Mockito.anyBoolean(), Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.anyBoolean(),
+            Mockito.nullable(String.class), Mockito.any(TracingContext.class));
 
     new Thread(() -> {
       try {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -408,6 +408,14 @@ public class ITestAzureBlobFileSystemDelete extends
   public void testDeleteCheckIfParentLMTChange() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     AbfsConfiguration conf = getConfiguration();
+    /*
+     * LMT of parent directory doesn't change when delete directory triggered with
+     * DFS endpoint (both hns and non-hns account). In Blob endpoint, if there
+     * is no redirect for ingress / mkdirs, the LMT doesn't change. But in case
+     * of ingress redirection, the directory creation of parent overrides the
+     * path which changes the LMT. Hence, for tests running with redirect
+     * configuration, this test is ignored.
+     */
     Assume.assumeFalse(
         getPrefixMode(fs) == PrefixMode.BLOB && (conf.shouldMkdirFallbackToDfs()
             || conf.shouldIngressFallbackToDfs()));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -59,6 +59,7 @@ import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_MKDIRS_FALLBACK_TO_DFS;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_REDIRECT_DELETE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_REDIRECT_RENAME;
 import static org.mockito.ArgumentMatchers.any;
@@ -406,6 +407,10 @@ public class ITestAzureBlobFileSystemDelete extends
   @Test
   public void testDeleteCheckIfParentLMTChange() throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
+    AbfsConfiguration conf = getConfiguration();
+    Assume.assumeFalse(
+        getPrefixMode(fs) == PrefixMode.BLOB && (conf.shouldMkdirFallbackToDfs()
+            || conf.shouldIngressFallbackToDfs()));
     fs.mkdirs(new Path("/dir1/dir2"));
     fs.create(new Path("/dir1/dir2/file"));
     FileStatus status = fs.getFileStatus(new Path("/dir1"));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1962,6 +1962,7 @@ public class ITestAzureBlobFileSystemRename extends
   public void testBlobAtomicRenameSrcAndDstAreNotLeftLeased() throws Exception {
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
     assumeNonHnsAccountBlobEndpoint(fs);
+    Assume.assumeFalse(getConfiguration().shouldIngressFallbackToDfs());
     fs.setWorkingDirectory(new Path("/"));
     fs.create(new Path("/hbase/dir1/blob1"));
     fs.create(new Path("/hbase/dir1/blob2"));


### PR DESCRIPTION
If the ingress config to DFS is true, the mkdirs fired from delete has to follow it. It can not go thorugh the blob endpoint for creating directory.


Changes:
1. the createDirectory in delete flow will happen by calling `store.createDirectory` which has intellgence of choosing right endpoint as per the configs.
2. Added a new field in `store.createDirectory` called `checkParentChain`. For blob endpoint, if the config is true, it will check for parents being explicit or not. Else, it will not check. Flows and the field input:
   - fs.mkdirs: true: reason being its the filesystem mkdirs API call and this is expected in current code base.
   - rename flow for creating dir on implicit src: true: reason being src directory would be required and the parent dir should be there. By keeping the field true, we are checking if parents are explicit or not. This is required because this is what was happening on ABFS_3.3.2_dev.
   -  In `store.setBlobMetadata` flow, if the path on which metadata to be set is implicit: false. @anujmodi2021 this is what we were discussing the other day that check on parentDirs not required here.
   -  from the delete flow: false: no need to check the parents of the parentDir. We just need to create parentDir.