### PR TITLE
Stop producer thread when consumer fails due to irrecoverable exception.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1613,8 +1613,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         getAbfsConfiguration().getBlobDirRenameMaxThread());
 
     if (blobList.getNextMarker() != null) {
-      new ListBlobProducer(listSrc,
-          client, listBlobQueue, blobList.getNextMarker(), tracingContext);
+      getListBlobProducer(listSrc, listBlobQueue, blobList.getNextMarker(),
+          tracingContext);
     } else {
       listBlobQueue.complete();
     }
@@ -1676,6 +1676,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     if (isAtomicRename) {
       renameAtomicityUtils.cleanup();
     }
+  }
+
+  @VisibleForTesting
+  ListBlobProducer getListBlobProducer(final String listSrc,
+      final ListBlobQueue listBlobQueue,
+      final String initNextMarker,
+      final TracingContext tracingContext) {
+    return new ListBlobProducer(listSrc,
+        client, listBlobQueue, initNextMarker, tracingContext);
   }
 
   @VisibleForTesting
@@ -1932,8 +1941,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         getAbfsConfiguration().getProducerQueueMaxSize(),
         getAbfsConfiguration().getBlobDirDeleteMaxThread());
     if (blobList.getNextMarker() != null) {
-      new ListBlobProducer(listSrc, client, queue,
-          blobList.getNextMarker(), tracingContext);
+      getListBlobProducer(listSrc, queue, blobList.getNextMarker(),
+          tracingContext);
     } else {
       queue.complete();
     }
@@ -2818,8 +2827,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
           listSrcBuilder.append(FORWARD_SLASH);
         }
         String listSrc = listSrcBuilder.toString();
-        new ListBlobProducer(listSrc, client, listBlobQueue, null,
-            tracingContext);
+        getListBlobProducer(listSrc, listBlobQueue, null, tracingContext);
         AbfsBlobLease abfsBlobLease = getBlobLease(src.toUri().getPath(),
             BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
         renameBlobDir(src, destination, tracingContext, listBlobQueue,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1743,6 +1743,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         } catch (InterruptedException | ExecutionException e) {
           LOG.error(String.format("rename from %s to %s failed", source,
               destination), e);
+          listBlobConsumer.fail();
           renameBlobExecutorService.shutdown();
           if (srcDirBlobLease != null) {
             srcDirBlobLease.free();
@@ -2015,6 +2016,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
               }
               LOG.error(String.format("Deleting Path %s failed",
                   blobPropertyPathStr), ex);
+              consumer.fail();
               throw new RuntimeException(ex);
             }
           }));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -41,4 +41,8 @@ public class ListBlobConsumer {
     return listBlobQueue.getIsCompleted()
         && listBlobQueue.size() == 0;
   }
+
+  public void fail() {
+    listBlobQueue.consumptionFailed();
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobConsumer.java
@@ -42,6 +42,9 @@ public class ListBlobConsumer {
         && listBlobQueue.size() == 0;
   }
 
+  /**
+   * Register consumer failure.
+   */
   public void fail() {
     listBlobQueue.consumptionFailed();
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -97,7 +97,7 @@ public class ListBlobProducer {
         if (nextMarker == null) {
           listBlobQueue.complete();
         }
-      } while(nextMarker != null);
+      } while(nextMarker != null && listBlobQueue.getConsumptionFailed());
     }).start();
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -97,7 +97,7 @@ public class ListBlobProducer {
         if (nextMarker == null) {
           listBlobQueue.complete();
         }
-      } while(nextMarker != null && listBlobQueue.getConsumptionFailed());
+      } while(nextMarker != null && !listBlobQueue.getConsumptionFailed());
     }).start();
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -34,6 +34,7 @@ public class ListBlobQueue {
   private int totalConsumed = 0;
 
   private Boolean isCompleted = false;
+  private Boolean isConsumptionFailed = false;
 
   private AzureBlobFileSystemException failureFromProducer;
 
@@ -83,6 +84,14 @@ public class ListBlobQueue {
 
   public void complete() {
     isCompleted = true;
+  }
+
+  void consumptionFailed() {
+    isConsumptionFailed = true;
+  }
+
+  public Boolean getConsumptionFailed() {
+    return isConsumptionFailed;
   }
 
   public Boolean getIsCompleted() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -86,11 +86,11 @@ public class ListBlobQueue {
     isCompleted = true;
   }
 
-  synchronized void consumptionFailed() {
+  void consumptionFailed() {
     isConsumptionFailed = true;
   }
 
-  synchronized Boolean getConsumptionFailed() {
+  Boolean getConsumptionFailed() {
     return isConsumptionFailed;
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobQueue.java
@@ -86,11 +86,11 @@ public class ListBlobQueue {
     isCompleted = true;
   }
 
-  void consumptionFailed() {
+  synchronized void consumptionFailed() {
     isConsumptionFailed = true;
   }
 
-  public Boolean getConsumptionFailed() {
+  synchronized Boolean getConsumptionFailed() {
     return isConsumptionFailed;
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2234,7 +2234,8 @@ public class ITestAzureBlobFileSystemRename extends
     assumeNonHnsAccountBlobEndpoint(getFileSystem());
     Configuration configuration = Mockito.spy(getRawConfiguration());
     configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "1");
-    AzureBlobFileSystem fs = Mockito.spy((AzureBlobFileSystem) FileSystem.get(configuration));
+    AzureBlobFileSystem fs = Mockito.spy(
+        (AzureBlobFileSystem) FileSystem.get(configuration));
 
     fs.mkdirs(new Path("/src"));
     ExecutorService executorService = Executors.newFixedThreadPool(10);
@@ -2264,7 +2265,8 @@ public class ITestAzureBlobFileSystemRename extends
       producers[0] = (ListBlobProducer) answer.callRealMethod();
       return producers[0];
     }).when(store).getListBlobProducer(Mockito.anyString(), Mockito.any(
-        ListBlobQueue.class), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+            ListBlobQueue.class), Mockito.nullable(String.class),
+        Mockito.any(TracingContext.class));
 
     Mockito.doAnswer(answer -> {
           String marker = answer.getArgument(0);
@@ -2281,20 +2283,24 @@ public class ITestAzureBlobFileSystemRename extends
             Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
 
     Mockito.doAnswer(answer -> {
-      spiedClient.acquireBlobLease(((Path)answer.getArgument(0)).toUri().getPath(), -1, answer.getArgument(2));
-      return answer.callRealMethod();
-    }).when(spiedClient).deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+          spiedClient.acquireBlobLease(
+              ((Path) answer.getArgument(0)).toUri().getPath(), -1,
+              answer.getArgument(2));
+          return answer.callRealMethod();
+        })
+        .when(spiedClient)
+        .deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class),
+            Mockito.any(TracingContext.class));
 
     intercept(Exception.class, () -> {
       fs.rename(new Path("/src"), new Path("/dst"));
     });
 
-
-
     producers[0].waitForProcessCompletion();
 
-    Mockito.verify(spiedClient, Mockito.atMost(3)).getListBlobs(Mockito.nullable(String.class),
-        Mockito.nullable(String.class), Mockito.nullable(String.class),
-        Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
+    Mockito.verify(spiedClient, Mockito.atMost(3))
+        .getListBlobs(Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.nullable(String.class),
+            Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -61,12 +61,15 @@ import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsLease;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperationTestUtil;
+import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
+import org.apache.hadoop.fs.azurebfs.services.ListBlobQueue;
 import org.apache.hadoop.fs.azurebfs.services.RenameAtomicityUtils;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.utils.TracingHeaderValidator;
 
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_LEASE_CREATE_NON_RECURSIVE;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_PRODUCER_QUEUE_MAX_SIZE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_REDIRECT_RENAME;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TRUE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_INGRESS_FALLBACK_TO_DFS;
@@ -2224,5 +2227,74 @@ public class ITestAzureBlobFileSystemRename extends
         .deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class),
             Mockito.any(TracingContext.class));
     return copied;
+  }
+
+  @Test
+  public void testProducerStopOnRenameFailure() throws Exception {
+    assumeNonHnsAccountBlobEndpoint(getFileSystem());
+    Configuration configuration = Mockito.spy(getRawConfiguration());
+    configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "1");
+    AzureBlobFileSystem fs = Mockito.spy((AzureBlobFileSystem) FileSystem.get(configuration));
+
+    fs.mkdirs(new Path("/src"));
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    List<Future> futureList = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      int iter = i;
+      Future future = executorService.submit(() -> {
+        try {
+          fs.create(new Path("/src/file" + iter));
+        } catch (IOException ex) {}
+      });
+      futureList.add(future);
+    }
+
+    for (Future future : futureList) {
+      future.get();
+    }
+
+    AbfsClient client = fs.getAbfsClient();
+    AbfsClient spiedClient = Mockito.spy(client);
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    store.setClient(spiedClient);
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+
+    ListBlobProducer[] producers = new ListBlobProducer[1];
+    Mockito.doAnswer(answer -> {
+      producers[0] = (ListBlobProducer) answer.callRealMethod();
+      return producers[0];
+    }).when(store).getListBlobProducer(Mockito.anyString(), Mockito.any(
+        ListBlobQueue.class), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+
+    Mockito.doAnswer(answer -> {
+          String marker = answer.getArgument(0);
+          String prefix = answer.getArgument(1);
+          String delimiter = answer.getArgument(2);
+          TracingContext tracingContext = answer.getArgument(4);
+          Object result = client.getListBlobs(marker, prefix, delimiter, 1,
+              tracingContext);
+          return result;
+        })
+        .when(spiedClient)
+        .getListBlobs(Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.nullable(String.class),
+            Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
+
+    Mockito.doAnswer(answer -> {
+      spiedClient.acquireBlobLease(((Path)answer.getArgument(0)).toUri().getPath(), -1, answer.getArgument(2));
+      return answer.callRealMethod();
+    }).when(spiedClient).deleteBlobPath(Mockito.any(Path.class), Mockito.nullable(String.class), Mockito.any(TracingContext.class));
+
+    intercept(Exception.class, () -> {
+      fs.rename(new Path("/src"), new Path("/dst"));
+    });
+
+
+
+    producers[0].waitForProcessCompletion();
+
+    Mockito.verify(spiedClient, Mockito.atMost(3)).getListBlobs(Mockito.nullable(String.class),
+        Mockito.nullable(String.class), Mockito.nullable(String.class),
+        Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -181,7 +181,6 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
   @Test
   public void testProducerStopOnConsumerFailure() throws Exception {
     Configuration configuration = Mockito.spy(getRawConfiguration());
-    configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "10");
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
         configuration);
 


### PR DESCRIPTION
When rename or delete dir fails, it doesn't stop producer thread. This PR aims to add this functionality in the rename and delete dir parts.


------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 777, Failures: 0, Errors: 1, Skipped: 184
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:368 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 777, Failures: 0, Errors: 1, Skipped: 184
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 38 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 140, Failures: 1, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 777, Failures: 0, Errors: 0, Skipped: 280
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 777, Failures: 0, Errors: 0, Skipped: 280
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAbfsFileSystemContractGetFileStatus>AbstractContractGetFileStatusTest.testComplexDirActions:156->AbstractContractGetFileStatusTest.checkListFilesComplexDirRecursive:280->AbstractContractGetFileStatusTest.verifyFileStats:514 » FileNotFound
[ERROR]   ITestAbfsFileSystemContractRename>AbstractContractRenameTest.testRenameWithNonEmptySubDir:234->AbstractFSContractTestBase.assertPathExists:317 » FileNotFound
[INFO]
[ERROR] Tests run: 279, Failures: 0, Errors: 2, Skipped: 45

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsListStatusRemoteIterator.testWithAbfsIteratorDisabled:168 [After removing every iterm found from the iterator, there should be no more elements in the fileNames] expected:<[0]> but was:<[1]>[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 777, Failures: 1, Errors: 1, Skipped: 184
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

```
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit 5194e32b2859d3149f7798bb9af2a1764e0326b9 (HEAD -> ABFS_3.3.2_dev_procuder_improvements, origin/ABFS_3.3.2_dev_procuder_improvements)
Author: Pranav Saxena <>
Date:   Wed Jul 19 06:14:24 2023 -0700

    listBlobQueue not to have synchronized methods
```