### PR TITLE
Rename Resume optimization: resume only if srcDir etag matches to the one with which rename was started.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1097,12 +1097,12 @@ public class AzureBlobFileSystem extends FileSystem
               new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
               tracingContext,
               ((AzureBlobFileSystemStore.VersionedFileStatus) fileStatus).getEtag());
-        renameAtomicityUtils.cleanup(
-            new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
-        throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,
-            AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
-            new FileNotFoundException(
-                qualifiedPath + ": No such file or directory."));
+          renameAtomicityUtils.cleanup(
+              new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
+          throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,
+              AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
+              new FileNotFoundException(
+                  qualifiedPath + ": No such file or directory."));
       }
       return fileStatus;
     } catch (AzureBlobFileSystemException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -362,7 +362,7 @@ public class AzureBlobFileSystem extends FileSystem
   }
 
   private FSDataInputStream open(final Path path,
-      final Optional<Configuration> options) throws IOException {
+      final Optional<OpenFileParameters> parameters) throws IOException {
     statIncrement(CALL_OPEN);
     Path qualifiedPath = makeQualified(path);
 
@@ -371,7 +371,7 @@ public class AzureBlobFileSystem extends FileSystem
           fileSystemId, FSOperationType.OPEN, tracingHeaderFormat,
           listener);
       InputStream inputStream = getAbfsStore().openFileForRead(qualifiedPath,
-          options, statistics, tracingContext);
+          parameters, statistics, tracingContext);
       return new FSDataInputStream(inputStream);
     } catch(AzureBlobFileSystemException ex) {
       checkException(path, ex);
@@ -379,6 +379,15 @@ public class AzureBlobFileSystem extends FileSystem
     }
   }
 
+  /**
+   * Takes config and other options through
+   * {@link org.apache.hadoop.fs.impl.OpenFileParameters}. Ensure that
+   * FileStatus entered is up-to-date, as it will be used to create the
+   * InputStream (with info such as contentLength, eTag)
+   * @param path The location of file to be opened
+   * @param parameters OpenFileParameters instance; can hold FileStatus,
+   *                   Configuration, bufferSize and mandatoryKeys
+   */
   @Override
   protected CompletableFuture<FSDataInputStream> openFileWithOptions(
       final Path path, final OpenFileParameters parameters) throws IOException {
@@ -389,7 +398,7 @@ public class AzureBlobFileSystem extends FileSystem
         "for " + path);
     return LambdaUtils.eval(
         new CompletableFuture<>(), () ->
-            open(path, Optional.of(parameters.getOptions())));
+            open(path, Optional.of(parameters)));
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -943,7 +943,7 @@ public class AzureBlobFileSystem extends FileSystem
                     ((AzureBlobFileSystemStore.VersionedFileStatus) renamePendingSrcFileStatus).getEtag());
             renameAtomicityUtils.cleanup(renamePendingFileStatus.getPath());
           } else {
-            delete(renamePendingFileStatus.getPath(), false);
+            getAbfsStore().delete(renamePendingFileStatus.getPath(), true, tracingContext);
           }
           result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
         }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1109,7 +1109,8 @@ public class AzureBlobFileSystem extends FileSystem
           fileStatus.getPath().toUri().getPath())) {
         FileStatus renamePendingJsonFileStatus;
         try {
-          renamePendingJsonFileStatus = getAbfsStore().getFileStatus(makeQualified(
+          renamePendingJsonFileStatus = getAbfsStore().getPathProperty(
+              makeQualified(
                   new Path(fileStatus.getPath().toUri().getPath() + SUFFIX)),
               tracingContext, true);
         } catch (AbfsRestOperationException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1102,7 +1102,7 @@ public class AzureBlobFileSystem extends FileSystem
          */
       final FileStatus fileStatus = getAbfsStore().getFileStatus(qualifiedPath,
           tracingContext, useBlobEndpoint);
-      final String filePathStr = path.toUri().getPath();
+      final String filePathStr = qualifiedPath.toUri().getPath();
       if (getAbfsStore().getPrefixMode() == PrefixMode.BLOB
           && fileStatus != null && fileStatus.isDirectory()
           && getAbfsStore().isAtomicRenameKey(filePathStr)) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -930,7 +930,8 @@ public class AzureBlobFileSystem extends FileSystem
           listener);
       FileStatus[] result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
       if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
-          == PrefixMode.BLOB && getAbfsStore().isAtomicRenameKey(qualifiedPath.toUri().getPath() + FORWARD_SLASH)) {
+          == PrefixMode.BLOB && getAbfsStore().isAtomicRenameKey(
+          qualifiedPath.toUri().getPath() + FORWARD_SLASH)) {
         Pair<FileStatus, FileStatus> renamePendingJsonAndSrcFileStatusPair
             = getAbfsStore().getRenamePendingFileStatus(result);
         FileStatus renamePendingSrcFileStatus

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -930,7 +930,7 @@ public class AzureBlobFileSystem extends FileSystem
           listener);
       FileStatus[] result = getAbfsStore().listStatus(qualifiedPath, tracingContext);
       if (getAbfsStore().getAbfsConfiguration().getPrefixMode()
-          == PrefixMode.BLOB && getAbfsStore().isAtomicRenameKey(f.toUri().getPath() + FORWARD_SLASH)) {
+          == PrefixMode.BLOB && getAbfsStore().isAtomicRenameKey(qualifiedPath.toUri().getPath() + FORWARD_SLASH)) {
         Pair<FileStatus, FileStatus> renamePendingJsonAndSrcFileStatusPair
             = getAbfsStore().getRenamePendingFileStatus(result);
         FileStatus renamePendingSrcFileStatus

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1119,12 +1119,14 @@ public class AzureBlobFileSystem extends FileSystem
           && getAbfsStore().isAtomicRenameKey(
           fileStatus.getPath().toUri().getPath())) {
         FileStatus renamePendingJsonFileStatus
-            = getAbfsStore().getRenamePendingFileStatusInDirectory(fileStatus,
-            tracingContext);
+            = getAbfsStore().getFileStatus(makeQualified(
+                new Path(fileStatus.getPath().toUri().getPath() + SUFFIX)),
+            tracingContext, true);
+
         if (renamePendingJsonFileStatus != null) {
           RenameAtomicityUtils renameAtomicityUtils
               = getRenameAtomicityUtilsForRedo(
-              new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
+              renamePendingJsonFileStatus.getPath(),
               tracingContext,
               ((AzureBlobFileSystemStore.VersionedFileStatus) fileStatus).getEtag(),
               getRenamePendingJsonInputStream(renamePendingJsonFileStatus));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1099,10 +1099,13 @@ public class AzureBlobFileSystem extends FileSystem
               ((AzureBlobFileSystemStore.VersionedFileStatus) fileStatus).getEtag());
           renameAtomicityUtils.cleanup(
               new Path(fileStatus.getPath().toUri().getPath() + SUFFIX));
-          throw new AbfsRestOperationException(HttpURLConnection.HTTP_NOT_FOUND,
-              AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
-              new FileNotFoundException(
-                  qualifiedPath + ": No such file or directory."));
+          if (renameAtomicityUtils.isRedone()) {
+            throw new AbfsRestOperationException(
+                HttpURLConnection.HTTP_NOT_FOUND,
+                AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(), null,
+                new FileNotFoundException(
+                    qualifiedPath + ": No such file or directory."));
+          }
       }
       return fileStatus;
     } catch (AzureBlobFileSystemException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1378,7 +1378,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
       final VersionedFileStatus fileStatus;
       if (parameterFileStatus instanceof VersionedFileStatus) {
-        Preconditions.checkArgument(parameterFileStatus.getPath().equals(path),
+        Preconditions.checkArgument(parameterFileStatus.getPath()
+                .equals(path.makeQualified(this.uri, path)),
             String.format(
                 "Filestatus path [%s] does not match with given path [%s]",
                 parameterFileStatus.getPath(), path));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -3125,16 +3125,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @throws IOException exception thrown from the call to {@link #getPathStatus(Path, TracingContext)}
    * method.
    */
-  public boolean getRenamePendingFileStatusInDirectory(final FileStatus fileStatus,
+  public FileStatus getRenamePendingFileStatusInDirectory(final FileStatus fileStatus,
       final TracingContext tracingContext) throws IOException {
     try {
-      getFileStatus(
+      return getFileStatus(
           new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
           tracingContext, true);
-      return true;
     } catch (AbfsRestOperationException ex) {
       if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-        return false;
+        return null;
       }
       throw ex;
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1242,11 +1242,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
             .build();
   }
 
-  /**
-   * Creates a directory on the given path.
-   *
-   * @return ETag of the directory created on DFS or blob endpoint.
-   */
   public String createDirectory(final Path path, final FileSystem.Statistics statistics, final FsPermission permission,
       final FsPermission umask,
       final Boolean checkParentChain,
@@ -3072,6 +3067,16 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return null;
   }
 
+  /**
+   * Returns the fileStatus of srcDir that has to be renamed for which the
+   * pendingJson file is created.
+   *
+   * @param fileStatuses array of fileStatus of files/directories from which the
+   * required directory is needed to be retrieved.
+   * @param renamePendingJsonFileStatus fileStatus for the pendingJson file created
+   * corresponding to the directory being renamed.
+   * @return fileStatus of the srcDirectory is in the array of fileStatus else null.
+   */
   public FileStatus getRenamePendingSrcFileStatus(final FileStatus[] fileStatuses,
       FileStatus renamePendingJsonFileStatus) {
     if (renamePendingJsonFileStatus == null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1289,7 +1289,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
               isNamespaceEnabled ? getOctalNotation(umask) : null, false, null,
               tracingContext);
       perfInfo.registerResult(op.getResult()).registerSuccess(true);
-      return extractEtagHeader(op.getResult());
+      return op.getResult().getResponseHeader(HttpHeaderConfigurations.ETAG);
     }
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2805,7 +2805,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   RenameAtomicityUtils.RedoRenameInvocation getRedoRenameInvocation(final TracingContext tracingContext) {
     return new RenameAtomicityUtils.RedoRenameInvocation() {
       @Override
-      public void redo(final Path destination, final Path src)
+      public void redo(final Path destination, final Path src,
+          final String srcEtag)
           throws AzureBlobFileSystemException {
 
         ListBlobQueue listBlobQueue = new ListBlobQueue(
@@ -3048,6 +3049,23 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   public FileStatus getRenamePendingFileStatus(final FileStatus[] fileStatuses) {
     for (FileStatus fileStatus : fileStatuses) {
       if (fileStatus.getPath().toUri().getPath().endsWith(SUFFIX)) {
+        return fileStatus;
+      }
+    }
+    return null;
+  }
+
+  public FileStatus getRenamePendingSrcFileStatus(final FileStatus[] fileStatuses,
+      FileStatus renamePendingJsonFileStatus) {
+    if (renamePendingJsonFileStatus == null) {
+      return null;
+    }
+    String srcPathSrc = renamePendingJsonFileStatus.getPath()
+        .toUri()
+        .getPath()
+        .split(SUFFIX)[0];
+    for (FileStatus fileStatus : fileStatuses) {
+      if (fileStatus.getPath().toUri().getPath().equals(srcPathSrc)) {
         return fileStatus;
       }
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2828,6 +2828,11 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
            abfsBlobLease = getBlobLease(src.toUri().getPath(),
               BLOB_LEASE_ONE_MINUTE_DURATION, tracingContext);
         } catch (AbfsRestOperationException ex) {
+          /*
+           * The required blob might be deleted in between the last check (from
+           * GetFileStatus or ListStatus) and the leaseAcquire. Hence, catching
+           * HTTP_NOT_FOUND error.
+           */
           if (ex.getStatusCode() == HTTP_NOT_FOUND) {
             return;
           }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -3115,31 +3115,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   /**
-   * For a given directory, returns back the fileStatus information for the
-   * RenamePending JSON file for the directory.
-   *
-   * @param fileStatus FileStatus object of the directory for which JSON file has
-   * to be searched.
-   * @param tracingContext TracingContext object for tracing the backend server calls
-   * for the operation.
-   * @throws IOException exception thrown from the call to {@link #getPathStatus(Path, TracingContext)}
-   * method.
-   */
-  public FileStatus getRenamePendingFileStatusInDirectory(final FileStatus fileStatus,
-      final TracingContext tracingContext) throws IOException {
-    try {
-      return getFileStatus(
-          new Path(fileStatus.getPath().toUri().getPath() + SUFFIX),
-          tracingContext, true);
-    } catch (AbfsRestOperationException ex) {
-      if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-        return null;
-      }
-      throw ex;
-    }
-  }
-
-  /**
    * A File status with version info extracted from the etag value returned
    * in a LIST or HEAD request.
    * The etag is included in the java serialization.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsInputStream.java
@@ -148,7 +148,16 @@ public class AbfsInputStream extends FSInputStream implements CanUnbuffer,
     this.streamStatistics = abfsInputStreamContext.getStreamStatistics();
     this.inputStreamId = createInputStreamId();
     this.tracingContext = new TracingContext(tracingContext);
-    this.tracingContext.setOperation(FSOperationType.READ);
+    /*
+     * If this inputStream is getting opened in listStatus or GetFileStatus, it would
+     * be in the flow of rename-resume. It required that all operations have the
+     * same primaryId and opType as that of the listStatus or getFileStatus which
+     * is invoking the rename-resume.
+     */
+    if (tracingContext.getOpType() != FSOperationType.LISTSTATUS
+        && this.tracingContext.getOpType() != FSOperationType.GET_FILESTATUS) {
+      this.tracingContext.setOperation(FSOperationType.READ);
+    }
     this.tracingContext.setStreamID(inputStreamId);
     this.context = abfsInputStreamContext;
     readAheadBlockSize = abfsInputStreamContext.getReadAheadBlockSize();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -196,7 +196,7 @@ public class RenameAtomicityUtils {
    *   OperationTime: "<YYYY-MM-DD HH:MM:SS.MMM>",
    *   OldFolderName: "<key>",
    *   NewFolderName: "<key>"
-   *   Etag: "<etag of the src-directory>"
+   *   ETag: "<etag of the src-directory>"
    * }
    *
    * Here's a sample:
@@ -205,7 +205,7 @@ public class RenameAtomicityUtils {
    *  OperationUTCTime: "2014-07-01 23:50:35.572",
    *  OldFolderName: "user/ehans/folderToRename",
    *  NewFolderName: "user/ehans/renamedFolder"
-   *  Etag: "ETag"
+   *  ETag: "ETag"
    * } }</pre>
    * @throws IOException Thrown when fail to write file.
    */

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -66,6 +66,7 @@ public class RenameAtomicityUtils {
   private Path srcPath;
   private Path dstPath;
   private TracingContext tracingContext;
+  private Boolean isReDone;
 
   private static final int MAX_RENAME_PENDING_FILE_SIZE = 10000000;
   private static final int FORMATTING_BUFFER = 10000;
@@ -96,6 +97,9 @@ public class RenameAtomicityUtils {
         && renamePendingFileInfo.eTag.equalsIgnoreCase(srcEtag)) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
           renamePendingFileInfo.src);
+      isReDone = true;
+    } else {
+      isReDone = false;
     }
   }
 
@@ -282,7 +286,7 @@ public class RenameAtomicityUtils {
         + "  OperationUTCTime: \"" + time + "\",\n"
         + "  OldFolderName: " + quote(srcPath.toUri().getPath()) + ",\n"
         + "  NewFolderName: " + quote(dstPath.toUri().getPath()) + ",\n"
-        + "  ETag: \"" + eTag + "\"\n"
+        + "  ETag: " + eTag + "\n"
         + "}\n";
 
     return contents;
@@ -382,5 +386,9 @@ public class RenameAtomicityUtils {
   public static interface RedoRenameInvocation {
     void redo(Path destination, Path src) throws
         AzureBlobFileSystemException;
+  }
+
+  public Boolean isRedone() {
+    return isReDone;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -50,7 +50,7 @@ import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 /**
  * For a directory enabled for atomic-rename, before rename starts, a
  * file with -RenamePending.json suffix is created. In this file, the states required
- * for the rename are given. This file is created by {@link #preRename(Boolean)} ()} method.
+ * for the rename are given. This file is created by {@link #preRename(Boolean, String)} ()} method.
  * This is important in case the JVM process crashes during rename, the atomicity
  * will be maintained, when the job calls {@link AzureBlobFileSystem#listStatus(Path)}
  * or {@link AzureBlobFileSystem#getFileStatus(Path)}. On these API calls to filesystem,
@@ -149,13 +149,17 @@ public class RenameAtomicityUtils {
     // initialize this object's fields
     JsonNode oldFolderName = json.get("OldFolderName");
     JsonNode newFolderName = json.get("NewFolderName");
+    JsonNode eTag = json.get("ETag");
+
     if (oldFolderName != null && StringUtils.isNotEmpty(
         oldFolderName.textValue())
         && newFolderName != null && StringUtils.isNotEmpty(
-        newFolderName.textValue())) {
+        newFolderName.textValue()) && eTag != null && StringUtils.isNotEmpty(
+        eTag.textValue())) {
       RenamePendingFileInfo renamePendingFileInfo = new RenamePendingFileInfo();
       renamePendingFileInfo.destination = new Path(newFolderName.textValue());
       renamePendingFileInfo.src = new Path(oldFolderName.textValue());
+      renamePendingFileInfo.eTag = eTag.textValue();
       return renamePendingFileInfo;
     }
     return null;
@@ -187,6 +191,7 @@ public class RenameAtomicityUtils {
    *   OperationTime: "<YYYY-MM-DD HH:MM:SS.MMM>",
    *   OldFolderName: "<key>",
    *   NewFolderName: "<key>"
+   *   Etag: "<etag of the src-directory>"
    * }
    *
    * Here's a sample:
@@ -195,15 +200,17 @@ public class RenameAtomicityUtils {
    *  OperationUTCTime: "2014-07-01 23:50:35.572",
    *  OldFolderName: "user/ehans/folderToRename",
    *  NewFolderName: "user/ehans/renamedFolder"
+   *  Etag: "ETag"
    * } }</pre>
    * @throws IOException Thrown when fail to write file.
    */
-  public void preRename(final Boolean isCreateOperationOnBlobEndpoint) throws IOException {
+  public void preRename(final Boolean isCreateOperationOnBlobEndpoint,
+      final String eTag) throws IOException {
     Path path = getRenamePendingFilePath();
     LOG.debug("Preparing to write atomic rename state to {}", path.toString());
     OutputStream output = null;
 
-    String contents = makeRenamePendingFileContents();
+    String contents = makeRenamePendingFileContents(eTag);
 
     // Write file.
     try {
@@ -262,7 +269,7 @@ public class RenameAtomicityUtils {
    *
    * @return JSON string which represents the operation.
    */
-  private String makeRenamePendingFileContents() {
+  private String makeRenamePendingFileContents(final String eTag) {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
     String time = sdf.format(new Date());
@@ -273,7 +280,8 @@ public class RenameAtomicityUtils {
         + "  FormatVersion: \"1.0\",\n"
         + "  OperationUTCTime: \"" + time + "\",\n"
         + "  OldFolderName: " + quote(srcPath.toUri().getPath()) + ",\n"
-        + "  NewFolderName: " + quote(dstPath.toUri().getPath()) + "\n"
+        + "  NewFolderName: " + quote(dstPath.toUri().getPath()) + ",\n"
+        + "  ETag: \"" + eTag + "\"\n"
         + "}\n";
 
     return contents;
@@ -367,6 +375,7 @@ public class RenameAtomicityUtils {
   private static class RenamePendingFileInfo {
     public Path destination;
     public Path src;
+    public String eTag;
   }
 
   public static interface RedoRenameInvocation {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -92,7 +92,8 @@ public class RenameAtomicityUtils {
       throws IOException {
     this.azureBlobFileSystem = azureBlobFileSystem;
     final RenamePendingFileInfo renamePendingFileInfo = readFile(path);
-    if (renamePendingFileInfo != null) {
+    if (renamePendingFileInfo != null
+        && renamePendingFileInfo.eTag.equalsIgnoreCase(srcEtag)) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
           renamePendingFileInfo.src, srcEtag);
     }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
@@ -91,7 +90,7 @@ public class RenameAtomicityUtils {
       final Path renamePendingJsonPath,
       final RedoRenameInvocation redoRenameInvocation,
       final String srcEtag,
-      final FSDataInputStream renamePendingJsonInputStream)
+      final AbfsInputStream renamePendingJsonInputStream)
       throws IOException {
     this.azureBlobFileSystem = azureBlobFileSystem;
     final RenamePendingFileInfo renamePendingFileInfo = readFile(
@@ -107,7 +106,7 @@ public class RenameAtomicityUtils {
   }
 
   private RenamePendingFileInfo readFile(final Path redoFile,
-      final FSDataInputStream redoFileInputStream)
+      final AbfsInputStream redoFileInputStream)
       throws IOException {
     Path f = redoFile;
     byte[] bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -274,10 +274,13 @@ public class RenameAtomicityUtils {
    *
    * @return JSON string which represents the operation.
    */
-  private String makeRenamePendingFileContents(final String eTag) {
+  private String makeRenamePendingFileContents(String eTag) {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
     String time = sdf.format(new Date());
+    if(!eTag.startsWith("\"") && !eTag.endsWith("\"")) {
+      eTag = quote(eTag);
+    }
 
     // Make file contents as a string. Again, quote file names, escaping
     // characters as appropriate.

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -88,11 +88,14 @@ public class RenameAtomicityUtils {
   }
 
   public RenameAtomicityUtils(final AzureBlobFileSystem azureBlobFileSystem,
-      final Path path, final RedoRenameInvocation redoRenameInvocation,
-      final String srcEtag)
+      final Path renamePendingJsonPath,
+      final RedoRenameInvocation redoRenameInvocation,
+      final String srcEtag,
+      final FSDataInputStream renamePendingJsonInputStream)
       throws IOException {
     this.azureBlobFileSystem = azureBlobFileSystem;
-    final RenamePendingFileInfo renamePendingFileInfo = readFile(path);
+    final RenamePendingFileInfo renamePendingFileInfo = readFile(
+        renamePendingJsonPath, renamePendingJsonInputStream);
     if (renamePendingFileInfo != null
         && renamePendingFileInfo.eTag.equalsIgnoreCase(srcEtag)) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
@@ -103,12 +106,12 @@ public class RenameAtomicityUtils {
     }
   }
 
-  private RenamePendingFileInfo readFile(final Path redoFile)
+  private RenamePendingFileInfo readFile(final Path redoFile,
+      final FSDataInputStream redoFileInputStream)
       throws IOException {
     Path f = redoFile;
-    FSDataInputStream input = azureBlobFileSystem.open(f);
     byte[] bytes = new byte[MAX_RENAME_PENDING_FILE_SIZE];
-    int l = input.read(bytes);
+    int l = redoFileInputStream.read(bytes);
     if (l <= 0) {
       // Jira HADOOP-12678 -Handle empty rename pending metadata file during
       // atomic rename in redo path. If during renamepending file is created

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -87,13 +87,14 @@ public class RenameAtomicityUtils {
   }
 
   public RenameAtomicityUtils(final AzureBlobFileSystem azureBlobFileSystem,
-      final Path path, final RedoRenameInvocation redoRenameInvocation)
+      final Path path, final RedoRenameInvocation redoRenameInvocation,
+      final String srcEtag)
       throws IOException {
     this.azureBlobFileSystem = azureBlobFileSystem;
     final RenamePendingFileInfo renamePendingFileInfo = readFile(path);
     if (renamePendingFileInfo != null) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
-          renamePendingFileInfo.src);
+          renamePendingFileInfo.src, srcEtag);
     }
   }
 
@@ -369,7 +370,7 @@ public class RenameAtomicityUtils {
   }
 
   public static interface RedoRenameInvocation {
-    void redo(Path destination, Path src) throws
+    void redo(Path destination, Path src, final String srcEtag) throws
         AzureBlobFileSystemException;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameAtomicityUtils.java
@@ -95,7 +95,7 @@ public class RenameAtomicityUtils {
     if (renamePendingFileInfo != null
         && renamePendingFileInfo.eTag.equalsIgnoreCase(srcEtag)) {
       redoRenameInvocation.redo(renamePendingFileInfo.destination,
-          renamePendingFileInfo.src, srcEtag);
+          renamePendingFileInfo.src);
     }
   }
 
@@ -380,7 +380,7 @@ public class RenameAtomicityUtils {
   }
 
   public static interface RedoRenameInvocation {
-    void redo(Path destination, Path src, final String srcEtag) throws
+    void redo(Path destination, Path src) throws
         AzureBlobFileSystemException;
   }
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
@@ -34,7 +34,8 @@ public class RenameNonAtomicUtils extends RenameAtomicityUtils {
   }
 
   @Override
-  public void preRename(final Boolean isCreateOperationOnBlobEndpoint)
+  public void preRename(final Boolean isCreateOperationOnBlobEndpoint,
+      final String eTag)
       throws IOException {
 
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/RenameNonAtomicUtils.java
@@ -44,4 +44,9 @@ public class RenameNonAtomicUtils extends RenameAtomicityUtils {
   public void cleanup() throws IOException {
 
   }
+
+  @Override
+  public Boolean isRedone() {
+    return true;
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.security.AbfsDelegationTokenManager;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
 import org.apache.hadoop.fs.azurebfs.services.AbfsOutputStream;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.azurebfs.services.ITestAbfsClient;
@@ -449,7 +450,13 @@ public abstract class AbstractAbfsIntegrationTest extends
   }
 
   public boolean isNamespaceEnabled(final AzureBlobFileSystem fs) throws AzureBlobFileSystemException {
-    return fs.getAbfsStore().getIsNamespaceEnabled(getTestTracingContext(fs, true));
+    return fs.getAbfsStore()
+        .getIsNamespaceEnabled(getTestTracingContext(fs, true));
+  }
+
+  public void setAbfsClient(AzureBlobFileSystemStore abfsStore,
+      AbfsClient client) {
+    abfsStore.setClient(client);
   }
 
   public Path makeQualified(Path path) throws java.io.IOException {

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -315,9 +315,9 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
     Assert.assertFalse(fileStatus.isDirectory());
 
-    Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
+    Mockito.verify(store, times(2)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
-    Mockito.verify(store, times(0)).getListBlobs(Mockito.any(Path.class),
+    Mockito.verify(store, times(1)).getListBlobs(Mockito.any(Path.class),
             Mockito.nullable(String.class), Mockito.nullable(String.class),
             Mockito.any(TracingContext.class), Mockito.any(Integer.class),
             Mockito.any(Boolean.class));
@@ -337,7 +337,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
     Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
-    Mockito.verify(store, times(1)).getListBlobs(Mockito.any(Path.class),
+    Mockito.verify(store, times(0)).getListBlobs(Mockito.any(Path.class),
             Mockito.nullable(String.class), Mockito.nullable(String.class),
             Mockito.any(TracingContext.class), Mockito.any(Integer.class),
             Mockito.any(Boolean.class));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -317,10 +317,20 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
     Mockito.verify(store, times(2)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
-    Mockito.verify(store, times(1)).getListBlobs(Mockito.any(Path.class),
-            Mockito.nullable(String.class), Mockito.nullable(String.class),
-            Mockito.any(TracingContext.class), Mockito.any(Integer.class),
-            Mockito.any(Boolean.class));
+    final AbfsConfiguration configuration= fs.getAbfsStore().getAbfsConfiguration();
+    final int listBlobAssertionTimes;
+    if (!configuration.shouldMkdirFallbackToDfs()
+        && !configuration.shouldReadFallbackToDfs()
+        && !configuration.shouldIngressFallbackToDfs()) {
+      listBlobAssertionTimes = 1;
+    } else{
+      listBlobAssertionTimes = 0;
+    }
+
+    Mockito.verify(store, times(listBlobAssertionTimes)).getListBlobs(Mockito.any(Path.class),
+        Mockito.nullable(String.class), Mockito.nullable(String.class),
+        Mockito.any(TracingContext.class), Mockito.any(Integer.class),
+        Mockito.any(Boolean.class));
   }
 
   @Test
@@ -335,9 +345,19 @@ public class ITestAzureBlobFileSystemFileStatus extends
 
     Assert.assertTrue(fileStatus.isDirectory());
 
+    final AbfsConfiguration configuration= fs.getAbfsStore().getAbfsConfiguration();
+    final int listBlobAssertionTimes;
+    if (!configuration.shouldMkdirFallbackToDfs()
+        && !configuration.shouldReadFallbackToDfs()
+        && !configuration.shouldIngressFallbackToDfs()) {
+      listBlobAssertionTimes = 1;
+    } else{
+      listBlobAssertionTimes = 0;
+    }
+
     Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
-    Mockito.verify(store, times(0)).getListBlobs(Mockito.any(Path.class),
+    Mockito.verify(store, times(listBlobAssertionTimes)).getListBlobs(Mockito.any(Path.class),
             Mockito.nullable(String.class), Mockito.nullable(String.class),
             Mockito.any(TracingContext.class), Mockito.any(Integer.class),
             Mockito.any(Boolean.class));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,8 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
+import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.azurebfs.utils.TracingHeaderValidator;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.mockito.Mock;
@@ -445,5 +448,52 @@ public class ITestAzureBlobFileSystemListStatus extends
     Assertions.assertThat(fileStatus.isDirectory()).isEqualTo(true);
     Assertions.assertThat(fileStatus.isFile()).isEqualTo(false);
     Assertions.assertThat(fileStatus.getLen()).isEqualTo(0);
+  }
+
+  @Test
+  public void testListStatusNotTriesToRenameResumeForNonAtomicDir()
+      throws Exception {
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    Mockito.doReturn(new FileStatus[1])
+        .when(store)
+        .listStatus(Mockito.any(Path.class), Mockito.any(
+            TracingContext.class));
+    fs.listStatus(new Path("/testDir/"));
+    Mockito.verify(store, Mockito.times(0))
+        .getRenamePendingFileStatus(Mockito.any(FileStatus[].class));
+  }
+
+  @Test
+  public void testListStatusTriesToRenameResumeForAtomicDir() throws Exception {
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    Mockito.doReturn(new FileStatus[0])
+        .when(store)
+        .listStatus(Mockito.any(Path.class), Mockito.any(
+            TracingContext.class));
+    fs.listStatus(new Path("/hbase/"));
+    Mockito.verify(store, Mockito.times(1))
+        .getRenamePendingFileStatus(Mockito.any(FileStatus[].class));
+  }
+
+  @Test
+  public void testListStatusTriesToRenameResumeForAbsoluteAtomicDir()
+      throws Exception {
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    Mockito.doReturn(new FileStatus[0])
+        .when(store)
+        .listStatus(Mockito.any(Path.class), Mockito.any(
+            TracingContext.class));
+    fs.listStatus(new Path("/hbase"));
+    Mockito.verify(store, Mockito.times(1))
+        .getRenamePendingFileStatus(Mockito.any(FileStatus[].class));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -500,12 +500,12 @@ public class ITestAzureBlobFileSystemRename extends
     }
     spiedFsForListPath.listStatus(new Path("hbase/test1/test2"));
     /*
-     * The invocation of getFileStatus will happen on the reinvocation of listStatus
+     * The invocation of getPathProperty will happen on the reinvocation of listStatus
      * of /hbase/test2/test3 as after the resume, there will be no listing for the path
      * and hence, getFileStatus would be required.
      */
     Mockito.verify(spiedStoreForListPath, Mockito.times(1))
-        .getFileStatus(Mockito.any(Path.class),
+        .getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
@@ -645,12 +645,12 @@ public class ITestAzureBlobFileSystemRename extends
     final FileStatus[] listFileResult = spiedFsForListPath.listStatus(
         new Path("hbase/test1"));
     /*
-     * The invocation of getFileStatus will happen on the reinvocation of listStatus
+     * The invocation of getPathProperty will happen on the reinvocation of listStatus
      * of /hbase/test2/test3 as after the resume, there will be no listing for the path
      * and hence, getFileStatus would be required.
      */
     Mockito.verify(spiedStoreForListPath, Mockito.times(1))
-        .getFileStatus(Mockito.any(Path.class),
+        .getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
@@ -800,11 +800,11 @@ public class ITestAzureBlobFileSystemRename extends
     Assert.assertTrue(notFoundExceptionReceived);
     Assert.assertNull(fileStatus);
     /*
-     * GetFileStatus on store would be called to get FileStatus for srcDirectory
+     * GetPathProperty on store would be called to get FileStatus for srcDirectory
      * and the corresponding renamePendingJson file.
      */
     Mockito.verify(spiedStoreForListPath, Mockito.times(2))
-        .getFileStatus(Mockito.any(Path.class),
+        .getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2213,7 +2213,7 @@ public class ITestAzureBlobFileSystemRename extends
         })
         .when(fs)
         .getRenameAtomicityUtilsForRedo(Mockito.any(Path.class),
-            Mockito.any(TracingContext.class), );
+            Mockito.any(TracingContext.class), Mockito.anyString());
 
     Mockito.doAnswer(answer -> {
           answer.callRealMethod();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1141,7 +1141,7 @@ public class ITestAzureBlobFileSystemRename extends
      * and the corresponding renamePendingJson file.
      */
     Mockito.verify(spiedStoreForListPath, Mockito.times(2))
-        .getFileStatus(Mockito.any(Path.class),
+        .getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(srcDir)));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2213,7 +2213,7 @@ public class ITestAzureBlobFileSystemRename extends
         })
         .when(fs)
         .getRenameAtomicityUtilsForRedo(Mockito.any(Path.class),
-            Mockito.any(TracingContext.class));
+            Mockito.any(TracingContext.class), );
 
     Mockito.doAnswer(answer -> {
           answer.callRealMethod();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -2246,7 +2246,7 @@ public class ITestAzureBlobFileSystemRename extends
     fs.delete(new Path("/hbase/testDir"), true);
     AtomicInteger copied = assertTracingContextOnRenameResumeProcess(fs, store,
         client, FSOperationType.LISTSTATUS);
-    fs.listStatus(new Path("/hbase"));
+    Assertions.assertThat(fs.listStatus(new Path("/hbase"))).hasSize(1);
     Assertions.assertThat(copied.get()).isEqualTo(0);
   }
 
@@ -2270,7 +2270,7 @@ public class ITestAzureBlobFileSystemRename extends
       }
       return answer.callRealMethod();
     }).when(client).acquireBlobLease(Mockito.anyString(), Mockito.anyInt(), Mockito.any(TracingContext.class));
-    fs.listStatus(new Path("/hbase"));
+    Assertions.assertThat(fs.listStatus(new Path("/hbase"))).hasSize(1);
     Assertions.assertThat(copied.get()).isEqualTo(0);
   }
 
@@ -2290,7 +2290,7 @@ public class ITestAzureBlobFileSystemRename extends
     fs.mkdirs(new Path("/hbase/testDir"));
     AtomicInteger copied = assertTracingContextOnRenameResumeProcess(fs, store,
         client, FSOperationType.LISTSTATUS);
-    fs.listStatus(new Path("/hbase"));
+    Assertions.assertThat(fs.listStatus(new Path("/hbase"))).hasSize(2);
     Assertions.assertThat(copied.get()).isEqualTo(0);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -436,6 +436,12 @@ public class ITestAzureBlobFileSystemRename extends
 
     //call listPath API, it will recover the rename atomicity.
     final AzureBlobFileSystem spiedFsForListPath = Mockito.spy(fs);
+    final AzureBlobFileSystemStore spiedStoreForListPath = Mockito.spy(
+        spiedFsForListPath.getAbfsStore());
+    Mockito.doReturn(spiedStoreForListPath)
+        .when(spiedFsForListPath)
+        .getAbfsStore();
+
     /*
      * Check if the fs.delete is on the renameJson file.
      */
@@ -493,6 +499,14 @@ public class ITestAzureBlobFileSystemRename extends
       }
     }
     spiedFsForListPath.listStatus(new Path("hbase/test1/test2"));
+    /*
+     * The invocation of getFileStatus will happen on the reinvocation of listStatus
+     * of /hbase/test2/test3 as after the resume, there will be no listing for the path
+     * and hence, getFileStatus would be required.
+     */
+    Mockito.verify(spiedStoreForListPath, Mockito.times(1))
+        .getFileStatus(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(
@@ -563,6 +577,11 @@ public class ITestAzureBlobFileSystemRename extends
 
     //call listPath API, it will recover the rename atomicity.
     final AzureBlobFileSystem spiedFsForListPath = Mockito.spy(fs);
+    final AzureBlobFileSystemStore spiedStoreForListPath = Mockito.spy(
+        spiedFsForListPath.getAbfsStore());
+    Mockito.doReturn(spiedStoreForListPath)
+        .when(spiedFsForListPath)
+        .getAbfsStore();
 
     /*
      * Check if the fs.delete is on the renameJson file.
@@ -625,6 +644,14 @@ public class ITestAzureBlobFileSystemRename extends
     }
     final FileStatus[] listFileResult = spiedFsForListPath.listStatus(
         new Path("hbase/test1"));
+    /*
+     * The invocation of getFileStatus will happen on the reinvocation of listStatus
+     * of /hbase/test2/test3 as after the resume, there will be no listing for the path
+     * and hence, getFileStatus would be required.
+     */
+    Mockito.verify(spiedStoreForListPath, Mockito.times(1))
+        .getFileStatus(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(
@@ -697,6 +724,11 @@ public class ITestAzureBlobFileSystemRename extends
 
     //call listPath API, it will recover the rename atomicity.
     final AzureBlobFileSystem spiedFsForListPath = Mockito.spy(fs);
+    final AzureBlobFileSystemStore spiedStoreForListPath = Mockito.spy(
+        spiedFsForListPath.getAbfsStore());
+    Mockito.doReturn(spiedStoreForListPath)
+        .when(spiedFsForListPath)
+        .getAbfsStore();
 
     /*
      * Check if the fs.delete is on the renameJson file.
@@ -767,6 +799,13 @@ public class ITestAzureBlobFileSystemRename extends
     }
     Assert.assertTrue(notFoundExceptionReceived);
     Assert.assertNull(fileStatus);
+    /*
+     * GetFileStatus on store would be called to get FileStatus for srcDirectory
+     * and the corresponding renamePendingJson file.
+     */
+    Mockito.verify(spiedStoreForListPath, Mockito.times(2))
+        .getFileStatus(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.anyBoolean());
     Assert.assertTrue(deletedCount.get() == 3);
     Assert.assertFalse(spiedFsForListPath.exists(new Path(failedCopyPath)));
     Assert.assertTrue(spiedFsForListPath.exists(new Path(

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -247,9 +247,11 @@ public class TestAbfsInputStream extends
     abfsStore.openFileForRead(testFile,
         Optional.empty(), null,
         tracingContext);
-    verify(mockClient, times(1).description(
-        "GetPathStatus should be invoked when FileStatus not provided"))
-        .getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+    if (getPrefixMode(getFileSystem()) == PrefixMode.DFS) {
+      verify(mockClient, times(1).description(
+          "GetPathStatus should be invoked when FileStatus not provided"))
+          .getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+    }
 
     Mockito.reset(mockClient); //clears invocation count for next test case
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsInputStream.java
@@ -19,32 +19,40 @@
 package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.Test;
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
+import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystemStore;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.TimeoutException;
 import org.apache.hadoop.fs.azurebfs.contracts.services.ReadBufferStatus;
 import org.apache.hadoop.fs.azurebfs.utils.TestCachedSASToken;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
-import org.mockito.Mockito;
+import org.apache.hadoop.fs.impl.OpenFileParameters;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -197,6 +205,106 @@ public class TestAbfsInputStream extends
     super();
     // Reduce thresholdAgeMilliseconds to 3 sec for the tests
     ReadBufferManager.getBufferManager().setThresholdAgeMilliseconds(REDUCED_READ_BUFFER_AGE_THRESHOLD);
+  }
+
+  private void writeBufferToNewFile(Path testFile, byte[] buffer) throws IOException {
+    AzureBlobFileSystem fs = getFileSystem();
+    fs.create(testFile);
+    FSDataOutputStream out = fs.append(testFile);
+    out.write(buffer);
+    out.close();
+  }
+
+  private void verifyOpenWithProvidedStatus(Path path, FileStatus fileStatus,
+      byte[] buf, AbfsRestOperationType source)
+      throws IOException, ExecutionException, InterruptedException {
+    byte[] readBuf = new byte[buf.length];
+    AzureBlobFileSystem fs = getFileSystem();
+    FutureDataInputStreamBuilder builder = fs.openFile(path);
+    builder.withFileStatus(fileStatus);
+    FSDataInputStream in = builder.build().get();
+    assertEquals(String.format(
+        "Open with fileStatus [from %s result]: Incorrect number of bytes read",
+        source), buf.length, in.read(readBuf));
+    assertArrayEquals(String
+        .format("Open with fileStatus [from %s result]: Incorrect read data",
+            source), readBuf, buf);
+  }
+
+  private void checkGetPathStatusCalls(Path testFile, FileStatus fileStatus,
+      AzureBlobFileSystemStore abfsStore, AbfsClient mockClient,
+      AbfsRestOperationType source, TracingContext tracingContext)
+      throws IOException {
+
+    // verify GetPathStatus not invoked when FileStatus is provided
+    abfsStore.openFileForRead(testFile, Optional
+        .ofNullable(new OpenFileParameters().withStatus(fileStatus)), null, tracingContext);
+    verify(mockClient, times(0).description((String.format(
+        "FileStatus [from %s result] provided, GetFileStatus should not be invoked",
+        source)))).getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+
+    // verify GetPathStatus invoked when FileStatus not provided
+    abfsStore.openFileForRead(testFile,
+        Optional.empty(), null,
+        tracingContext);
+    verify(mockClient, times(1).description(
+        "GetPathStatus should be invoked when FileStatus not provided"))
+        .getPathStatus(anyString(), anyBoolean(), any(TracingContext.class));
+
+    Mockito.reset(mockClient); //clears invocation count for next test case
+  }
+
+  @Test
+  public void testOpenFileWithOptions() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    String testFolder = "/testFolder";
+    Path smallTestFile = new Path(testFolder + "/testFile0");
+    Path largeTestFile = new Path(testFolder + "/testFile1");
+    fs.mkdirs(new Path(testFolder));
+    int readBufferSize = getConfiguration().getReadBufferSize();
+    byte[] smallBuffer = new byte[5];
+    byte[] largeBuffer = new byte[readBufferSize + 5];
+    new Random().nextBytes(smallBuffer);
+    new Random().nextBytes(largeBuffer);
+    writeBufferToNewFile(smallTestFile, smallBuffer);
+    writeBufferToNewFile(largeTestFile, largeBuffer);
+
+    FileStatus[] getFileStatusResults = {fs.getFileStatus(smallTestFile),
+        fs.getFileStatus(largeTestFile)};
+    FileStatus[] listStatusResults = fs.listStatus(new Path(testFolder));
+
+    // open with fileStatus from GetPathStatus
+    verifyOpenWithProvidedStatus(smallTestFile, getFileStatusResults[0],
+        smallBuffer, AbfsRestOperationType.GetPathStatus);
+    verifyOpenWithProvidedStatus(largeTestFile, getFileStatusResults[1],
+        largeBuffer, AbfsRestOperationType.GetPathStatus);
+
+    // open with fileStatus from ListStatus
+    verifyOpenWithProvidedStatus(smallTestFile, listStatusResults[0], smallBuffer,
+        AbfsRestOperationType.ListPaths);
+    verifyOpenWithProvidedStatus(largeTestFile, listStatusResults[1], largeBuffer,
+        AbfsRestOperationType.ListPaths);
+
+    // verify number of GetPathStatus invocations
+    AzureBlobFileSystemStore abfsStore = getAbfsStore(fs);
+    AbfsClient mockClient = spy(getClient(fs));
+    setAbfsClient(abfsStore, mockClient);
+    TracingContext tracingContext = getTestTracingContext(fs, false);
+    checkGetPathStatusCalls(smallTestFile, getFileStatusResults[0],
+        abfsStore, mockClient, AbfsRestOperationType.GetPathStatus, tracingContext);
+    checkGetPathStatusCalls(largeTestFile, getFileStatusResults[1],
+        abfsStore, mockClient, AbfsRestOperationType.GetPathStatus, tracingContext);
+    checkGetPathStatusCalls(smallTestFile, listStatusResults[0],
+        abfsStore, mockClient, AbfsRestOperationType.ListPaths, tracingContext);
+    checkGetPathStatusCalls(largeTestFile, listStatusResults[1],
+        abfsStore, mockClient, AbfsRestOperationType.ListPaths, tracingContext);
+
+    // Verify with incorrect filestatus
+    getFileStatusResults[0].setPath(new Path("wrongPath"));
+    intercept(ExecutionException.class,
+        () -> verifyOpenWithProvidedStatus(smallTestFile,
+            getFileStatusResults[0], smallBuffer,
+            AbfsRestOperationType.GetPathStatus));
   }
 
   /**


### PR DESCRIPTION
1. Resume the rename only if srcDirectory is present and it's etag matches to the one that was there at the time of rename. Else, just delete the pendingJson.
2. PendingJson will now have Etag information of the srcDir at the time of rename.
3. There is listStatus done after its found that renamePendingJson is there. But since there can be scenario where rename resume shouldnt be done (like srcDir not there, or original srcDir is changed(etag change)), the second listStatus shall be redundant. In case of not requirement, it will not be called.


------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 782, Failures: 0, Errors: 1, Skipped: 189
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 782, Failures: 0, Errors: 1, Skipped: 189
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:276->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=155).
[INFO]
[ERROR] Tests run: 782, Failures: 1, Errors: 0, Skipped: 280
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 10 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 140, Failures: 1, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 782, Failures: 0, Errors: 0, Skipped: 280
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 140, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 782, Failures: 0, Errors: 1, Skipped: 189
[INFO] Results:
[INFO]
[WARNING] Tests run: 279, Failures: 0, Errors: 0, Skipped: 45

Time taken: 47 mins 6 secs.
```
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit bab6499eb99e289d75b98a71ad2c8afac1a248e7 (HEAD -> ABFS_3.3.2_dev_redo_optimization, origin/ABFS_3.3.2_dev_redo_optimization_less, origin/ABFS_3.3.2_dev_redo_optimization, ABFS_3.3.2_dev_redo_optimization_less)
Author: Pranav Saxena <>
Date:   Mon Jul 24 06:41:27 2023 -0700

    asssertion if the listStatus API of FS will give correct result when we are not making redundant listStatus backend call

```