### PR TITLE
Create File Optimizations and Removing redundant code.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -390,23 +390,6 @@ public class AzureBlobFileSystem extends FileSystem
             open(path, Optional.of(parameters.getOptions())));
   }
 
-  /**
-   * This handling makes sure that if request to create file for an existing directory or subpath
-   * comes that should fail.
-   * @param path The path to validate.
-   * @param tracingContext The tracingContext.
-   */
-  private void validatePathOrSubPathDoesNotExist(final Path path, TracingContext tracingContext) throws IOException {
-    List<BlobProperty> blobList = abfsStore.getListBlobs(path, null, null,
-            tracingContext, 2, true);
-    if (blobList.size() > 0 || abfsStore.checkIsDirectory(path, tracingContext)) {
-      throw new AbfsRestOperationException(HTTP_CONFLICT,
-              AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
-              PATH_EXISTS,
-              null);
-    }
-  }
-
   private boolean shouldRedirect(FSOperationType type, TracingContext context)
           throws AzureBlobFileSystemException {
     if (getIsNamespaceEnabled(context)) {
@@ -461,10 +444,10 @@ public class AzureBlobFileSystem extends FileSystem
             fileSystemId, FSOperationType.CREATE, overwrite, tracingHeaderFormat, listener);
 
     Path qualifiedPath = makeQualified(f);
+    FileStatus fileStatus = tryGetFileStatus(qualifiedPath, tracingContext);
     // This fix is needed for create idempotency, should throw error if overwrite is false and file status is not null.
     boolean fileOverwrite = overwrite;
     if (!fileOverwrite) {
-      FileStatus fileStatus = tryGetFileStatus(qualifiedPath, tracingContext);
       if (fileStatus != null) {
         // path references a file and overwrite is disabled
         throw new FileAlreadyExistsException(f + " already exists");
@@ -473,7 +456,12 @@ public class AzureBlobFileSystem extends FileSystem
     }
 
     if (prefixMode == PrefixMode.BLOB) {
-      validatePathOrSubPathDoesNotExist(qualifiedPath, tracingContext);
+      if (fileStatus != null && fileStatus.isDirectory()) {
+        throw new AbfsRestOperationException(HTTP_CONFLICT,
+            AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
+            PATH_EXISTS,
+            null);
+      }
       if (!blobParentDirPresentChecked) {
         Path parent = qualifiedPath.getParent();
         if (parent != null && !parent.isRoot()) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1092,25 +1092,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   /**
-   * Returns true if the path is a directory.
-   * @param path path to check for file or directory.
-   * @param tracingContext tracingContext.
-   * @return true or false.
-   */
-  boolean checkIsDirectory(Path path, TracingContext tracingContext) throws IOException {
-   BlobProperty blobProperty;
-    try {
-      blobProperty = getBlobProperty(path, tracingContext);
-    } catch (AbfsRestOperationException ex) {
-      if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        throw ex;
-      }
-      return false;
-    }
-    return blobProperty.getIsDirectory();
-  }
-
-  /**
    * Conditional create overwrite flow ensures that create overwrites is done
    * only if there is match for eTag of existing file.
    * @param relativePath

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -91,7 +91,6 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
   /**
    * Test that setting metadata over marker blob do not override
    * x-ms-meta-hdi_IsFolder
-   * TODO: Confirm Expected Behavior
    * @throws Exception
    */
   @Test


### PR DESCRIPTION
Changes in the PR:
There as a function validatePathOrSubPathDoesNotExist in create() flow that checks if the path passed is not a directory(neither implicit nor explicit). For this we used to make 2 API calls one listBlob and other getBlobProperty. This was similar to check getFileStatus that we were doing only for cases where overwrite was false.

So for cases with overwrite false we had 4 API calls and with overwrite true we had 2 API calls. Now we will have 2 API calls for all the cases and validatePathOrSubPathDoesNotExist will not be used anymore.