### PR TITLE
Refactor Directory Check

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/AzureNativeFileSystemStore.java
@@ -807,7 +807,7 @@ public class AzureNativeFileSystemStore implements NativeFileSystemStore {
     LOG.debug("Page blob directories:  {}", setToString(pageBlobDirs));
 
     // User-agent
-    userAgentId = "wasbdriverV2.3";
+    userAgentId = "wasbdriverV2.4";
 
     // Extract the directories that should contain block blobs with compaction
     blockBlobWithCompationDirs = getDirectorySet(

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -862,7 +862,7 @@ public class AbfsConfiguration{
   }
 
   public String getCustomUserAgentPrefix() {
-    return "abfsdriverV2.3";
+    return "abfsdriverV2.4";
   }
 
   public String getClusterName() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -1018,7 +1018,7 @@ public class AzureBlobFileSystem extends FileSystem
       TracingContext tracingContext = new TracingContext(clientCorrelationId,
               fileSystemId, FSOperationType.MKDIR, false, tracingHeaderFormat,
               listener);
-      abfsStore.createDirectory(qualifiedPath, statistics,
+      getAbfsStore().createDirectory(qualifiedPath, statistics,
               permission == null ? FsPermission.getDirDefault() : permission,
               FsPermission.getUMask(getConf()), true, tracingContext);
       statIncrement(DIRECTORIES_CREATED);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1308,6 +1308,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
     FileStatus fileStatus = tryGetPathProperty(path, tracingContext, true);
     Boolean isDirectory = fileStatus != null ? fileStatus.isDirectory() : false;
+    if (fileStatus != null && !isDirectory) {
+      throw new AbfsRestOperationException(HTTP_CONFLICT,
+              AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
+              PATH_EXISTS,
+              null);
+    }
     if (isDirectory) {
       return;
     }
@@ -1315,6 +1321,12 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     while (current != null && !current.isRoot()) {
       fileStatus = tryGetPathProperty(path, tracingContext, true);
       isDirectory = fileStatus != null ? fileStatus.isDirectory() : false;
+      if (fileStatus != null && !isDirectory) {
+        throw new AbfsRestOperationException(HTTP_CONFLICT,
+                AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
+                PATH_EXISTS,
+                null);
+      }
       if (isDirectory) {
         break;
       }
@@ -2090,6 +2102,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   /**
    * Method to make a call to get path property based on various configs-
    * like whether to go over blob/dfs endpoint, whether path provided is root etc.
+   * This does not segregate between implicit and explicit paths.
    * @param path Path to call the downstream get property method on
    * @param tracingContext Current tracing context for the call
    * @param useBlobEndpoint Flag indicating whether to use blob endpoint

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1323,37 +1323,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     }
   }
 
-  /**
-   * Checks if the path is directory and throws exception if it exists as a file.
-   * @param path path to check for file or directory.
-   * @param tracingContext the tracingcontext.
-   * @return true or false.
-   * @throws IOException
-   */
-  private boolean checkPathIsDirectory(Path path, TracingContext tracingContext) throws IOException {
-    BlobProperty blobProperty = null;
-    try {
-      blobProperty = getBlobProperty(path, tracingContext);
-    } catch (AbfsRestOperationException ex) {
-      if (ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        throw ex;
-      }
-    }
-
-    if (blobProperty != null) {
-      boolean isDir = blobProperty.getIsDirectory();
-      if (!isDir) {
-        throw new AbfsRestOperationException(HTTP_CONFLICT,
-                AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
-                PATH_EXISTS,
-                null);
-      }
-      return true;
-    }
-    return false;
-  }
-
-
   public AbfsInputStream openFileForRead(final Path path,
       final FileSystem.Statistics statistics, TracingContext tracingContext)
       throws IOException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -926,7 +926,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       delimiter = "";
     }
     do {
-      AbfsRestOperation op = client.getListBlobs(
+      AbfsRestOperation op = getClient().getListBlobs(
           nextMarker, prefix, delimiter, maxResult, tracingContext
       );
       BlobList blobList = op.getResult().getBlobList();
@@ -2099,7 +2099,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
    * @return VersionedFileStatus object for given path
    * @throws IOException
    */
-  private FileStatus getPathProperty(Path path, TracingContext tracingContext, Boolean useBlobEndpoint) throws IOException {
+  FileStatus getPathProperty(Path path, TracingContext tracingContext, Boolean useBlobEndpoint) throws IOException {
     AbfsPerfInfo perfInfo = startTracking("getFileStatus", "undetermined");
     final AbfsRestOperation op;
     Boolean isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
@@ -2260,7 +2260,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
          * a single entry corresponding to the directory name will be returned as BlobPrefix.
          */
         try (AbfsPerfInfo perfInfo = startTracking("listStatus", "getListBlobs")) {
-          AbfsRestOperation op = client.getListBlobs(
+          AbfsRestOperation op = getClient().getListBlobs(
               continuation, prefix, delimiter, abfsConfiguration.getListMaxResults(),
               tracingContext
           );

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2054,89 +2054,15 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
   }
 
   public FileStatus getFileStatus(Path path, TracingContext tracingContext, boolean useBlobEndpoint) throws IOException {
-    try (AbfsPerfInfo perfInfo = startTracking("getFileStatus", "undetermined")) {
+    try {
       boolean isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
       LOG.debug("getFileStatus filesystem: {} path: {} isNamespaceEnabled: {}",
               client.getFileSystem(),
               path,
               isNamespaceEnabled);
 
-      final AbfsRestOperation op;
-      if (useBlobEndpoint) {
-        LOG.debug("getFileStatus filesystem call over blob endpoint: {} path: {}",
-                client.getFileSystem(),
-                path);
+      return getPathProperty(path, tracingContext, useBlobEndpoint);
 
-        if (path.isRoot()) {
-          perfInfo.registerCallee("getContainerProperties");
-          op = client.getContainerProperty(tracingContext);
-        } else {
-          perfInfo.registerCallee("getBlobProperty");
-          op = client.getBlobProperty(path, tracingContext);
-        }
-      } else {
-        if (path.isRoot()) {
-          if (isNamespaceEnabled) {
-            perfInfo.registerCallee("getAclStatus");
-            op = client.getAclStatus(getRelativePath(path), tracingContext);
-          } else {
-            perfInfo.registerCallee("getFilesystemProperties");
-            op = client.getFilesystemProperties(tracingContext);
-          }
-        } else {
-          perfInfo.registerCallee("getPathStatus");
-          op = client.getPathStatus(getRelativePath(path), false, tracingContext);
-        }
-      }
-
-      perfInfo.registerResult(op.getResult());
-      final long blockSize = abfsConfiguration.getAzureBlockSize();
-      final AbfsHttpOperation result = op.getResult();
-
-      String eTag = extractEtagHeader(result);
-      final String lastModified = result.getResponseHeader(HttpHeaderConfigurations.LAST_MODIFIED);
-      final String permissions = result.getResponseHeader((HttpHeaderConfigurations.X_MS_PERMISSIONS));
-      final boolean hasAcl = AbfsPermission.isExtendedAcl(permissions);
-      final long contentLength;
-      final boolean resourceIsDir;
-
-      if (path.isRoot()) {
-        contentLength = 0;
-        resourceIsDir = true;
-      } else {
-        contentLength = parseContentLength(result.getResponseHeader(HttpHeaderConfigurations.CONTENT_LENGTH));
-        if (useBlobEndpoint) {
-          resourceIsDir = result.getResponseHeader(X_MS_META_HDI_ISFOLDER) != null;
-        } else {
-          resourceIsDir = parseIsDirectory(result.getResponseHeader(HttpHeaderConfigurations.X_MS_RESOURCE_TYPE));
-        }
-      }
-
-      final String transformedOwner = identityTransformer.transformIdentityForGetRequest(
-              result.getResponseHeader(HttpHeaderConfigurations.X_MS_OWNER),
-              true,
-              userName);
-
-      final String transformedGroup = identityTransformer.transformIdentityForGetRequest(
-              result.getResponseHeader(HttpHeaderConfigurations.X_MS_GROUP),
-              false,
-              primaryUserGroup);
-
-      perfInfo.registerSuccess(true);
-
-      return new VersionedFileStatus(
-              transformedOwner,
-              transformedGroup,
-              permissions == null ? new AbfsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL)
-                      : AbfsPermission.valueOf(permissions),
-              hasAcl,
-              contentLength,
-              resourceIsDir,
-              1,
-              blockSize,
-              DateTimeUtils.parseLastModifiedTime(lastModified),
-              path,
-              eTag);
     } catch (AbfsRestOperationException ex) {
       if (useBlobEndpoint && ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND && !path.isRoot()) {
         List<BlobProperty> blobProperties = getListBlobs(path, null, null, tracingContext, 2, true);
@@ -2162,6 +2088,101 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
         throw ex;
       }
     }
+  }
+
+  /**
+   * Method to make a call to get path property based on various configs-
+   * like whether to go over blob/dfs endpoint, whether path provided is root etc.
+   * @param path Path to call the downstream get property method on
+   * @param tracingContext Current tracing context for the call
+   * @param useBlobEndpoint Flag indicating whether to use blob endpoint
+   * @return VersionedFileStatus object for given path
+   * @throws IOException
+   */
+  private FileStatus getPathProperty(Path path, TracingContext tracingContext, Boolean useBlobEndpoint) throws IOException {
+    AbfsPerfInfo perfInfo = startTracking("getFileStatus", "undetermined");
+    final AbfsRestOperation op;
+    Boolean isNamespaceEnabled = getIsNamespaceEnabled(tracingContext);
+    if (useBlobEndpoint) {
+      LOG.debug("getPathProperty filesystem call over blob endpoint: {} path: {} isNamespaceEnabled: {}",
+              client.getFileSystem(),
+              path,
+              isNamespaceEnabled);
+
+      if (path.isRoot()) {
+        perfInfo.registerCallee("getContainerProperties");
+        op = client.getContainerProperty(tracingContext);
+      } else {
+        perfInfo.registerCallee("getBlobProperty");
+        op = client.getBlobProperty(path, tracingContext);
+      }
+    } else {
+      LOG.debug("getPathProperty filesystem call over dfs endpoint: {} path: {} isNamespaceEnabled: {}",
+              client.getFileSystem(),
+              path,
+              isNamespaceEnabled);
+      if (path.isRoot()) {
+        if (isNamespaceEnabled) {
+          perfInfo.registerCallee("getAclStatus");
+          op = client.getAclStatus(getRelativePath(path), tracingContext);
+        } else {
+          perfInfo.registerCallee("getFilesystemProperties");
+          op = client.getFilesystemProperties(tracingContext);
+        }
+      } else {
+        perfInfo.registerCallee("getPathStatus");
+        op = client.getPathStatus(getRelativePath(path), false, tracingContext);
+      }
+    }
+
+    perfInfo.registerResult(op.getResult());
+    final long blockSize = abfsConfiguration.getAzureBlockSize();
+    final AbfsHttpOperation result = op.getResult();
+
+    String eTag = extractEtagHeader(result);
+    final String lastModified = result.getResponseHeader(HttpHeaderConfigurations.LAST_MODIFIED);
+    final String permissions = result.getResponseHeader((HttpHeaderConfigurations.X_MS_PERMISSIONS));
+    final boolean hasAcl = AbfsPermission.isExtendedAcl(permissions);
+    final long contentLength;
+    final boolean resourceIsDir;
+
+    if (path.isRoot()) {
+      contentLength = 0;
+      resourceIsDir = true;
+    } else {
+      contentLength = parseContentLength(result.getResponseHeader(HttpHeaderConfigurations.CONTENT_LENGTH));
+      if (useBlobEndpoint) {
+        resourceIsDir = result.getResponseHeader(X_MS_META_HDI_ISFOLDER) != null;
+      } else {
+        resourceIsDir = parseIsDirectory(result.getResponseHeader(HttpHeaderConfigurations.X_MS_RESOURCE_TYPE));
+      }
+    }
+
+    final String transformedOwner = identityTransformer.transformIdentityForGetRequest(
+            result.getResponseHeader(HttpHeaderConfigurations.X_MS_OWNER),
+            true,
+            userName);
+
+    final String transformedGroup = identityTransformer.transformIdentityForGetRequest(
+            result.getResponseHeader(HttpHeaderConfigurations.X_MS_GROUP),
+            false,
+            primaryUserGroup);
+
+    perfInfo.registerSuccess(true);
+
+    return new VersionedFileStatus(
+            transformedOwner,
+            transformedGroup,
+            permissions == null ? new AbfsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL)
+                    : AbfsPermission.valueOf(permissions),
+            hasAcl,
+            contentLength,
+            resourceIsDir,
+            1,
+            blockSize,
+            DateTimeUtils.parseLastModifiedTime(lastModified),
+            path,
+            eTag);
   }
 
   /**
@@ -2269,7 +2290,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
       fileStatuses.addAll(fileMetadata.values());
 
       if (fileStatuses.size() == 0) {
-        FileStatus status = getFileStatus(path, tracingContext, true);
+        FileStatus status = getPathProperty(path, tracingContext, true);
         if (status.isFile()) {
           fileStatuses.add(status);
         }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2260,7 +2260,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
          * a single entry corresponding to the directory name will be returned as BlobPrefix.
          */
         try (AbfsPerfInfo perfInfo = startTracking("listStatus", "getListBlobs")) {
-          AbfsRestOperation op = getClient().getListBlobs(
+          AbfsRestOperation op = client.getListBlobs(
               continuation, prefix, delimiter, abfsConfiguration.getListMaxResults(),
               tracingContext
           );

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
@@ -303,13 +304,16 @@ public class ITestAzureBlobFileSystemFileStatus extends
   }
 
   @Test
-  public void testGetPathPropertyCalledExplicit() throws Exception {
+  public void testGetPathPropertyCalled() throws Exception {
+    Assume.assumeTrue(getFileSystem().getAbfsStore().getPrefixMode() == PrefixMode.BLOB);
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     Mockito.doReturn(store).when(fs).getAbfsStore();
 
     fs.create(new Path("/testGetPathProperty"));
-    fs.getFileStatus(new Path("/testGetPathProperty"));
+    FileStatus fileStatus = fs.getFileStatus(new Path("/testGetPathProperty"));
+
+    Assert.assertFalse(fileStatus.isDirectory());
 
     Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
@@ -327,7 +331,9 @@ public class ITestAzureBlobFileSystemFileStatus extends
     Mockito.doReturn(store).when(fs).getAbfsStore();
 
     createAzCopyDirectory(new Path("/testImplicitDirectory"));
-    fs.getFileStatus(new Path("/testImplicitDirectory"));
+    FileStatus fileStatus = fs.getFileStatus(new Path("/testImplicitDirectory"));
+
+    Assert.assertTrue(fileStatus.isDirectory());
 
     Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -49,6 +51,7 @@ import static org.apache.hadoop.fs.contract.ContractTestUtils.assertPathExists;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.rename;
 
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
+import static org.mockito.Mockito.times;
 
 /**
  * Test listStatus operation.
@@ -417,6 +420,32 @@ public class ITestAzureBlobFileSystemListStatus extends
     fs.mkdirs(testPath);
     FileStatus[] fileStatuses = fs.listStatus(testPath);
     Assertions.assertThat(fileStatuses.length).isEqualTo(0);
+  }
+
+  @Test
+  public void testListStatusUsesGfs() throws Exception {
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    AbfsClient client = Mockito.spy(store.getClient());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+    Mockito.doReturn(client).when(store).getClient();
+
+    intercept(FileNotFoundException.class, () ->
+            fs.listStatus(new Path("a/b")));
+
+    Mockito.verify(store, times(1)).getPathProperty(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.any(boolean.class));
+
+    // getListBlobs from within store should not be called - as this is invoked from getFileStatus
+    Mockito.verify(store, times(0)).getListBlobs(Mockito.any(Path.class),
+            Mockito.any(String.class), Mockito.any(String.class), Mockito.any(TracingContext.class),
+            Mockito.any(Integer.class), Mockito.any(Boolean.class));
+
+    // getListBlobs from client should be called once - the call for listStatus that would fail
+    // as this blob is actually non-existent
+    Mockito.verify(client, times(1)).getListBlobs(Mockito.nullable(String.class),
+            Mockito.nullable(String.class), Mockito.nullable(String.class),
+            Mockito.any(Integer.class), Mockito.any(TracingContext.class));
   }
 
   private void assertFileFileStatus(final FileStatus fileStatus,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -429,6 +429,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     AbfsClient client = Mockito.spy(store.getClient());
     Mockito.doReturn(store).when(fs).getAbfsStore();
     Mockito.doReturn(client).when(store).getClient();
+    store.setClient(client);
 
     intercept(FileNotFoundException.class, () ->
             fs.listStatus(new Path("a/b")));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -28,8 +28,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.assertj.core.api.Assertions;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
@@ -424,6 +426,7 @@ public class ITestAzureBlobFileSystemListStatus extends
 
   @Test
   public void testListStatusUsesGfs() throws Exception {
+    Assume.assumeTrue(getFileSystem().getAbfsStore().getPrefixMode() == PrefixMode.BLOB);
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
     AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
     AbfsClient client = Mockito.spy(store.getClient());

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -178,7 +178,7 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     fs.mkdirs(new Path("/src/dir"));
     Mockito.verify(testClient, Mockito.times(0)).getPathStatus(Mockito.any(String.class),
             Mockito.anyBoolean(), Mockito.any(TracingContext.class));
-    Mockito.verify(testClient, Mockito.times(1)).getBlobProperty(Mockito.any(Path.class),
+    Mockito.verify(testClient, Mockito.times(3)).getBlobProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class));
 
   }
@@ -191,9 +191,9 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     Mockito.doReturn(store).when(fs).getAbfsStore();
 
     fs.mkdirs(new Path("/testPath"));
-    Mockito.verify(store, Mockito.atLeast(1)).tryGetPathProperty(Mockito.any(Path.class),
+    Mockito.verify(store, Mockito.times(1)).tryGetPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
-    Mockito.verify(store, Mockito.atLeast(1)).getPathProperty(Mockito.any(Path.class),
+    Mockito.verify(store, Mockito.times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
 
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -178,7 +178,7 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     fs.mkdirs(new Path("/src/dir"));
     Mockito.verify(testClient, Mockito.times(0)).getPathStatus(Mockito.any(String.class),
             Mockito.anyBoolean(), Mockito.any(TracingContext.class));
-    Mockito.verify(testClient, Mockito.times(3)).getBlobProperty(Mockito.any(Path.class),
+    Mockito.verify(testClient, Mockito.atLeast(1)).getBlobProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class));
 
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -183,7 +183,6 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
 
   }
 
-
   @Test
   public void testGetPathPropertyCalledOnMkdir() throws Exception {
     AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
@@ -196,6 +195,18 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
     Mockito.verify(store, Mockito.times(1)).getPathProperty(Mockito.any(Path.class),
             Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
 
+  }
+
+  @Test
+  public void testMkdirWithExistingFilenameBlobEndpoint() throws Exception {
+    Assume.assumeTrue(getFileSystem().getAbfsStore().getPrefixMode() == PrefixMode.BLOB);
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+
+    fs.create(new Path("/testFilePath"));
+    intercept(FileAlreadyExistsException.class, () -> fs.mkdirs(new Path("/testFilePath")));
+    intercept(FileAlreadyExistsException.class, () -> fs.mkdirs(new Path("/testFilePath/newDir")));
   }
 }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -182,4 +182,20 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
             Mockito.any(TracingContext.class));
 
   }
+
+
+  @Test
+  public void testGetPathPropertyCalledOnMkdir() throws Exception {
+    AzureBlobFileSystem fs = Mockito.spy(getFileSystem());
+    AzureBlobFileSystemStore store = Mockito.spy(fs.getAbfsStore());
+    Mockito.doReturn(store).when(fs).getAbfsStore();
+
+    fs.mkdirs(new Path("/testPath"));
+    Mockito.verify(store, Mockito.atLeast(1)).tryGetPathProperty(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
+    Mockito.verify(store, Mockito.atLeast(1)).getPathProperty(Mockito.any(Path.class),
+            Mockito.any(TracingContext.class), Mockito.any(Boolean.class));
+
+  }
 }
+


### PR DESCRIPTION
Reducing redundant code and using getPathProperty for checking parent chain of given path for determining whether directory or not. 

This also updates the user agents.