### PR TITLE
No uri change till client. fs and store will have uri of config.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -191,13 +191,6 @@ public class AzureBlobFileSystem extends FileSystem
       blockOutputActiveBlocks = 1;
     }
 
-    if (configuration.getBoolean(FS_AZURE_ENABLE_BLOB_ENDPOINT, false)) {
-      if (uri.toString().contains(FileSystemUriSchemes.ABFS_DNS_PREFIX)) {
-        uri = changePrefixFromDfsToBlob(uri);
-        this.uri = uri;
-      }
-    }
-
     // AzureBlobFileSystemStore with params in builder.
     AzureBlobFileSystemStore.AzureBlobFileSystemStoreBuilder
         systemStoreBuilder =

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1465,9 +1465,9 @@ public class AbfsClient implements Closeable {
         SASTokenProvider.COPY_BLOB_SOURCE, abfsUriQueryBuilderSrc);
     final URL url = changePrefixFromDfsToBlob(createRequestUrl(dstBlobRelativePath,
         abfsUriQueryBuilderDst.toString()));
-    final String sourcePathUrl = createRequestUrl(
+    final String sourcePathUrl = changePrefixFromDfsToBlob(createRequestUrl(
         srcBlobRelativePath,
-        abfsUriQueryBuilderSrc.toString()).toString();
+        abfsUriQueryBuilderSrc.toString())).toString();
     List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     if (srcLeaseId != null) {
       requestHeaders.add(new AbfsHttpHeader(X_MS_SOURCE_LEASE_ID, srcLeaseId));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -195,6 +195,9 @@ public class AbfsClient implements Closeable {
   }
 
   private URL changePrefixFromDfsToBlob(URL url) throws InvalidUriException {
+    if (url.toString().contains(ABFS_DNS_PREFIX)) {
+      return url;
+    }
     try {
       url = new URL(url.toString().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX));
     } catch (MalformedURLException ex) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -321,12 +321,6 @@ public class AbfsClient implements Closeable {
     return op;
   }
 
-  private URL createBlobRequestUrl(final AbfsUriQueryBuilder abfsUriQueryBuilder)
-      throws AzureBlobFileSystemException {
-    return changePrefixFromDfsToBlob(
-        createRequestUrl(abfsUriQueryBuilder.toString()));
-  }
-
   public AbfsRestOperation setFilesystemProperties(final String properties, TracingContext tracingContext) throws AzureBlobFileSystemException {
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     // JDK7 does not support PATCH, so to workaround the issue we will use
@@ -565,13 +559,6 @@ public class AbfsClient implements Closeable {
       throw ex;
     }
     return op;
-  }
-
-  private URL createBlobRequestUrl(final String path,
-      final AbfsUriQueryBuilder abfsUriQueryBuilder)
-      throws AzureBlobFileSystemException {
-    return changePrefixFromDfsToBlob(
-        createRequestUrl(path, abfsUriQueryBuilder.toString()));
   }
 
   public AbfsRestOperation acquireLease(final String path, int duration, TracingContext tracingContext) throws AzureBlobFileSystemException {
@@ -1864,6 +1851,19 @@ public class AbfsClient implements Closeable {
       }
     }
     return sasToken;
+  }
+
+  private URL createBlobRequestUrl(final AbfsUriQueryBuilder abfsUriQueryBuilder)
+      throws AzureBlobFileSystemException {
+    return changePrefixFromDfsToBlob(
+        createRequestUrl(abfsUriQueryBuilder.toString()));
+  }
+
+  private URL createBlobRequestUrl(final String path,
+      final AbfsUriQueryBuilder abfsUriQueryBuilder)
+      throws AzureBlobFileSystemException {
+    return changePrefixFromDfsToBlob(
+        createRequestUrl(path, abfsUriQueryBuilder.toString()));
   }
 
   private URL createRequestUrl(final String query) throws AzureBlobFileSystemException {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -305,7 +305,7 @@ public class AbfsClient implements Closeable {
 
     appendSASTokenToQuery("",
         SASTokenProvider.CREATE_CONTAINER_OPERATION, abfsUriQueryBuilder);
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.CreateContainer,
@@ -427,7 +427,7 @@ public class AbfsClient implements Closeable {
 
     appendSASTokenToQuery("",
         SASTokenProvider.DELETE_CONTAINER_OPERATION, abfsUriQueryBuilder);
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.DeleteContainer,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -195,7 +195,7 @@ public class AbfsClient implements Closeable {
   }
 
   private URL changePrefixFromDfsToBlob(URL url) throws InvalidUriException {
-    if (url.toString().contains(ABFS_DNS_PREFIX)) {
+    if (url.toString().contains(WASB_DNS_PREFIX)) {
       return url;
     }
     try {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -194,6 +194,15 @@ public class AbfsClient implements Closeable {
     return url;
   }
 
+  private URL changePrefixFromDfsToBlob(URL url) throws InvalidUriException {
+    try {
+      url = new URL(url.toString().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX));
+    } catch (MalformedURLException ex) {
+      throw new InvalidUriException(url.toString());
+    }
+    return url;
+  }
+
   private String getBase64EncodedString(String key) {
     return getBase64EncodedString(key.getBytes(StandardCharsets.UTF_8));
   }
@@ -512,7 +521,7 @@ public class AbfsClient implements Closeable {
     String operation = SASTokenProvider.CREATE_FILE_OPERATION;
     appendSASTokenToQuery(path, operation, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
     if (metadata != null && !metadata.isEmpty()) {
       for (Map.Entry<String, String> entry : metadata.entrySet()) {
         requestHeaders.add(new AbfsHttpHeader(entry.getKey(), entry.getValue()));
@@ -581,7 +590,7 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery(path, SASTokenProvider.LEASE_OPERATION, abfsUriQueryBuilder);
 
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -627,7 +636,7 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, QUERY_PARAM_COMP_LEASE_VALUE);
     appendSASTokenToQuery(path, SASTokenProvider.LEASE_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -673,7 +682,7 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, QUERY_PARAM_COMP_LEASE_VALUE);
     appendSASTokenToQuery(path, SASTokenProvider.LEASE_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.LeasePath,
@@ -864,7 +873,7 @@ public class AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
             abfsUriQueryBuilder, cachedSasToken);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
     final AbfsRestOperation op = new AbfsRestOperation(
             AbfsRestOperationType.PutBlock,
             this,
@@ -931,7 +940,7 @@ public class AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
             abfsUriQueryBuilder, cachedSasToken);
 
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
     final AbfsRestOperation op = new AbfsRestOperation(
             AbfsRestOperationType.PutBlockList,
             this,
@@ -1137,7 +1146,7 @@ public class AbfsClient implements Closeable {
 
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCKLIST);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKLISTTYPE, COMMITTED);
-    final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
             AbfsRestOperationType.GetBlockList,
@@ -1169,6 +1178,7 @@ public class AbfsClient implements Closeable {
       LOG.debug("Read over Blob for read config value {} for path {} ",
               abfsConfiguration.shouldReadFallbackToDfs(), path);
       opType = AbfsRestOperationType.GetBlob;
+      url = changePrefixFromDfsToBlob(url);
     } else {
       if (url.toString().contains(WASB_DNS_PREFIX)) {
         url = changePrefixFromBlobtoDfs(url);
@@ -1453,8 +1463,8 @@ public class AbfsClient implements Closeable {
         SASTokenProvider.COPY_BLOB_DESTINATION, abfsUriQueryBuilderDst);
     appendSASTokenToQuery(srcBlobRelativePath,
         SASTokenProvider.COPY_BLOB_SOURCE, abfsUriQueryBuilderSrc);
-    final URL url = createRequestUrl(dstBlobRelativePath,
-        abfsUriQueryBuilderDst.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(dstBlobRelativePath,
+        abfsUriQueryBuilderDst.toString()));
     final String sourcePathUrl = createRequestUrl(
         srcBlobRelativePath,
         abfsUriQueryBuilderSrc.toString()).toString();
@@ -1493,8 +1503,8 @@ public class AbfsClient implements Closeable {
     String blobRelativePath = blobPath.toUri().getPath();
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.GET_BLOB_PROPERTIES_OPERATION, abfsUriQueryBuilder);
-    final URL url = createRequestUrl(blobRelativePath,
-        abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(blobRelativePath,
+        abfsUriQueryBuilder.toString()));
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetBlobProperties,
@@ -1521,7 +1531,7 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery("",
         SASTokenProvider.GET_CONTAINER_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetContainerProperties,
@@ -1550,8 +1560,8 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.GET_BLOB_METADATA_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(blobRelativePath,
-        abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(blobRelativePath,
+        abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetBlobMetadata,
@@ -1585,8 +1595,8 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.SET_BLOB_METADATA_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(blobRelativePath,
-        abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(blobRelativePath,
+        abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.SetBlobMetadata,
@@ -1616,7 +1626,7 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery("",
         SASTokenProvider.GET_CONTAINER_METADATA_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetContainerMetadata,
@@ -1650,7 +1660,7 @@ public class AbfsClient implements Closeable {
     appendSASTokenToQuery("",
         SASTokenProvider.SET_CONTAINER_METADATA_OPERATION, abfsUriQueryBuilder);
 
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
 
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.SetContainerMetadata,
@@ -1706,7 +1716,7 @@ public class AbfsClient implements Closeable {
     }
     appendSASTokenToQuery(null, SASTokenProvider.LIST_BLOB_OPERATION,
         abfsUriQueryBuilder);
-    final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(abfsUriQueryBuilder.toString()));
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     final AbfsRestOperation op = new AbfsRestOperation(
         AbfsRestOperationType.GetListBlobProperties,
@@ -1737,8 +1747,8 @@ public class AbfsClient implements Closeable {
     String blobRelativePath = blobPath.toUri().getPath();
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.DELETE_BLOB_OPERATION, abfsUriQueryBuilder);
-    final URL url = createRequestUrl(blobRelativePath,
-        abfsUriQueryBuilder.toString());
+    final URL url = changePrefixFromDfsToBlob(createRequestUrl(blobRelativePath,
+        abfsUriQueryBuilder.toString()));
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     if(leaseId != null) {
       requestHeaders.add(new AbfsHttpHeader(X_MS_LEASE_ID, leaseId));

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -874,16 +874,8 @@ public class AbfsClient implements Closeable {
             abfsUriQueryBuilder, cachedSasToken);
 
     final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.PutBlock,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders,
-            buffer,
-            reqParams.getoffset(),
-            reqParams.getLength(),
-            sasTokenForReuse);
+    final AbfsRestOperation op = getPutBlockOperation(buffer, reqParams, requestHeaders,
+        sasTokenForReuse, url);
     try {
       op.execute(tracingContext);
     } catch (AzureBlobFileSystemException e) {
@@ -908,6 +900,24 @@ public class AbfsClient implements Closeable {
       }
     }
     return op;
+  }
+
+  @VisibleForTesting
+  AbfsRestOperation getPutBlockOperation(final byte[] buffer,
+      final AppendRequestParameters reqParams,
+      final List<AbfsHttpHeader> requestHeaders,
+      final String sasTokenForReuse,
+      final URL url) {
+    return new AbfsRestOperation(
+        AbfsRestOperationType.PutBlock,
+        this,
+        HTTP_METHOD_PUT,
+        url,
+        requestHeaders,
+        buffer,
+        reqParams.getoffset(),
+        reqParams.getLength(),
+        sasTokenForReuse);
   }
 
   /**
@@ -941,17 +951,27 @@ public class AbfsClient implements Closeable {
             abfsUriQueryBuilder, cachedSasToken);
 
     final URL url = changePrefixFromDfsToBlob(createRequestUrl(path, abfsUriQueryBuilder.toString()));
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.PutBlockList,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders, buffer,
-            0,
-            buffer.length,
-            sasTokenForReuse);
+    final AbfsRestOperation op = getPutBlockListOperation(buffer,
+        requestHeaders, sasTokenForReuse,
+        url);
     op.execute(tracingContext);
     return op;
+  }
+
+  @VisibleForTesting
+  AbfsRestOperation getPutBlockListOperation(final byte[] buffer,
+      final List<AbfsHttpHeader> requestHeaders,
+      final String sasTokenForReuse,
+      final URL url) {
+    return new AbfsRestOperation(
+        AbfsRestOperationType.PutBlockList,
+        this,
+        HTTP_METHOD_PUT,
+        url,
+        requestHeaders, buffer,
+        0,
+        buffer.length,
+        sasTokenForReuse);
   }
 
   /*

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/AbstractAbfsIntegrationTest.java
@@ -328,11 +328,6 @@ public abstract class AbstractAbfsIntegrationTest extends
   }
 
   protected String getTestUrl() {
-    if (abfsConfig.shouldEnableBlobEndPoint()) {
-      if (testUrl.contains(ABFS_DNS_PREFIX)) {
-        testUrl = testUrl.replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
     return testUrl;
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
@@ -351,7 +351,8 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
 
 
   @Test
-  public void testListStatusIteratorReturnStatusWithPathWithSameUriGivenInConfig() throws Exception {
+  public void testListStatusIteratorReturnStatusWithPathWithSameUriGivenInConfig()
+      throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     String accountName = getAccountName();
     Boolean isAccountNameInDfs = accountName.contains(ABFS_DNS_PREFIX);
@@ -389,11 +390,12 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
       final String accountName,
       final String dnsAssertion,
       final Path path) throws IOException {
-    RemoteIterator<FileStatus> fileStatusRemoteIterator = fs.listStatusIterator(new Path(
-        "abfs://" + fs.getAbfsClient().getFileSystem() + "@" + accountName
-            + path.getParent().toUri().getPath()));
+    RemoteIterator<FileStatus> fileStatusRemoteIterator = fs.listStatusIterator(
+        new Path(
+            "abfs://" + fs.getAbfsClient().getFileSystem() + "@" + accountName
+                + path.getParent().toUri().getPath()));
 
-    while(fileStatusRemoteIterator.hasNext()) {
+    while (fileStatusRemoteIterator.hasNext()) {
       FileStatus fileStatus = fileStatusRemoteIterator.next();
       Assertions.assertThat(fileStatus.getPath().toString())
           .contains(dnsAssertion);
@@ -403,7 +405,7 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
         "abfs://" + fs.getAbfsClient().getFileSystem() + "@" + accountName
             + path.toUri().getPath()));
 
-    while(fileStatusRemoteIterator.hasNext()) {
+    while (fileStatusRemoteIterator.hasNext()) {
       FileStatus fileStatus = fileStatusRemoteIterator.next();
       Assertions.assertThat(fileStatus.getPath().toString())
           .contains(dnsAssertion);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
@@ -379,7 +379,7 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
       configuration.set(FS_DEFAULT_NAME_KEY,
           configuration.get(FS_DEFAULT_NAME_KEY)
               .replace(WASB_DNS_PREFIX, ABFS_DNS_PREFIX));
-      dnsAssertion = WASB_DNS_PREFIX;
+      dnsAssertion = ABFS_DNS_PREFIX;
     }
     fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     assertListStatusIteratorPath(fs, accountName, dnsAssertion, path);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsListStatusRemoteIterator.java
@@ -33,13 +33,18 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.azurebfs.services.AbfsListStatusRemoteIterator;
 import org.apache.hadoop.fs.azurebfs.services.ListingSupport;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -344,4 +349,64 @@ public class ITestAbfsListStatusRemoteIterator extends AbstractAbfsIntegrationTe
     return fileNames;
   }
 
+
+  @Test
+  public void testListStatusIteratorReturnStatusWithPathWithSameUriGivenInConfig() throws Exception {
+    AzureBlobFileSystem fs = getFileSystem();
+    String accountName = getAccountName();
+    Boolean isAccountNameInDfs = accountName.contains(ABFS_DNS_PREFIX);
+    String dnsAssertion;
+    if (isAccountNameInDfs) {
+      dnsAssertion = ABFS_DNS_PREFIX;
+    } else {
+      dnsAssertion = WASB_DNS_PREFIX;
+    }
+
+    final Path path = new Path("/testDir/file");
+    fs.create(path);
+    assertListStatusIteratorPath(fs, accountName, dnsAssertion, path);
+
+    final Configuration configuration;
+    if (isAccountNameInDfs) {
+      configuration = new Configuration(getRawConfiguration());
+      configuration.set(FS_DEFAULT_NAME_KEY,
+          configuration.get(FS_DEFAULT_NAME_KEY)
+              .replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX));
+      dnsAssertion = WASB_DNS_PREFIX;
+
+    } else {
+      configuration = new Configuration(getRawConfiguration());
+      configuration.set(FS_DEFAULT_NAME_KEY,
+          configuration.get(FS_DEFAULT_NAME_KEY)
+              .replace(WASB_DNS_PREFIX, ABFS_DNS_PREFIX));
+      dnsAssertion = WASB_DNS_PREFIX;
+    }
+    fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
+    assertListStatusIteratorPath(fs, accountName, dnsAssertion, path);
+  }
+
+  private void assertListStatusIteratorPath(final AzureBlobFileSystem fs,
+      final String accountName,
+      final String dnsAssertion,
+      final Path path) throws IOException {
+    RemoteIterator<FileStatus> fileStatusRemoteIterator = fs.listStatusIterator(new Path(
+        "abfs://" + fs.getAbfsClient().getFileSystem() + "@" + accountName
+            + path.getParent().toUri().getPath()));
+
+    while(fileStatusRemoteIterator.hasNext()) {
+      FileStatus fileStatus = fileStatusRemoteIterator.next();
+      Assertions.assertThat(fileStatus.getPath().toString())
+          .contains(dnsAssertion);
+    }
+
+    fileStatusRemoteIterator = fs.listStatusIterator(new Path(
+        "abfs://" + fs.getAbfsClient().getFileSystem() + "@" + accountName
+            + path.toUri().getPath()));
+
+    while(fileStatusRemoteIterator.hasNext()) {
+      FileStatus fileStatus = fileStatusRemoteIterator.next();
+      Assertions.assertThat(fileStatus.getPath().toString())
+          .contains(dnsAssertion);
+    }
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -224,8 +224,11 @@ public class ITestAzureBlobFileSystemCheckAccess
 
     //  When the driver does not know if the account is HNS enabled or not it
     //  makes a server call and fails
-    intercept(Exception.class, "\"This request is not authorized to perform this operation using "
-            + "this permission.\", 403", this::setTestUserFsNonHNS);
+    if(getAccountName().contains(WASB_DNS_PREFIX)) {
+      intercept(Exception.class,
+          "\"This request is not authorized to perform this operation using "
+              + "this permission.\", 403", this::setTestUserFsNonHNS);
+    }
 
     //  When the driver has already determined if the account is HNS enabled
     //  or not, and as the account is non HNS the AzureBlobFileSystem#access

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCheckAccess.java
@@ -114,11 +114,6 @@ public class ITestAzureBlobFileSystemCheckAccess
   private void setTestUserFsNonHNS() throws Exception {
     AzureBlobFileSystemStore abfsStore = getAbfsStore(getFileSystem());
     String accountName = this.getAccountName();
-    if (abfsStore.getPrefixMode() == PrefixMode.BLOB) {
-      if (abfsStore.getAbfsConfiguration().shouldEnableBlobEndPoint()) {
-        accountName = getAccountName().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
     checkIfConfigIsSet(FS_AZURE_ACCOUNT_OAUTH_CLIENT_ENDPOINT
             + "." + accountName);
     Configuration conf = Mockito.spy(getRawConfiguration());
@@ -131,6 +126,7 @@ public class ITestAzureBlobFileSystemCheckAccess
             + accountName, ClientCredsTokenProvider.class.getName());
     conf.setBoolean(AZURE_CREATE_REMOTE_FILESYSTEM_DURING_INITIALIZATION,
             false);
+    conf.set(FS_AZURE_ACCOUNT_IS_HNS_ENABLED, "");
     FileSystem testUserFsNonHns;
     testUserFsNonHns = FileSystem.newInstance(conf);
   }
@@ -224,11 +220,10 @@ public class ITestAzureBlobFileSystemCheckAccess
 
     //  When the driver does not know if the account is HNS enabled or not it
     //  makes a server call and fails
-    if(getAccountName().contains(WASB_DNS_PREFIX)) {
-      intercept(Exception.class,
-          "\"This request is not authorized to perform this operation using "
-              + "this permission.\", 403", this::setTestUserFsNonHNS);
-    }
+
+    intercept(Exception.class,
+        "\"This request is not authorized to perform this operation using "
+            + "this permission.\", 403", this::setTestUserFsNonHNS);
 
     //  When the driver has already determined if the account is HNS enabled
     //  or not, and as the account is non HNS the AzureBlobFileSystem#access

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -774,11 +774,7 @@ public class ITestAzureBlobFileSystemCreate extends
     Assume.assumeTrue(abfsStore.getPrefixMode() == PrefixMode.BLOB);
     Configuration configuration = Mockito.spy(getRawConfiguration());
     String accountName = getAccountName();
-    if (abfsStore.getPrefixMode() == PrefixMode.BLOB) {
-      if (abfsStore.getAbfsConfiguration().shouldEnableBlobEndPoint()) {
-        accountName = getAccountName().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
+
     configuration.set(FS_AZURE_CLIENT_PROVIDED_ENCRYPTION_KEY + "." + accountName, "abcd");
     intercept(InvalidConfigurationValueException.class, () -> (AzureBlobFileSystem) FileSystem.newInstance(configuration));
   }
@@ -792,11 +788,7 @@ public class ITestAzureBlobFileSystemCreate extends
     Assume.assumeTrue(abfsStore.getPrefixMode() == PrefixMode.BLOB);
     Configuration configuration = Mockito.spy(getRawConfiguration());
     String accountName = getAccountName();
-    if (abfsStore.getPrefixMode() == PrefixMode.BLOB) {
-      if (abfsStore.getAbfsConfiguration().shouldEnableBlobEndPoint()) {
-        accountName = getAccountName().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
+
     configuration.set(FS_AZURE_CLIENT_PROVIDED_ENCRYPTION_KEY + "." + accountName, "");
     intercept(InvalidConfigurationValueException.class, () -> (AzureBlobFileSystem) FileSystem.newInstance(configuration));
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -400,7 +400,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
       configuration.set(FS_DEFAULT_NAME_KEY,
           configuration.get(FS_DEFAULT_NAME_KEY)
               .replace(WASB_DNS_PREFIX, ABFS_DNS_PREFIX));
-      dnsAssertion = WASB_DNS_PREFIX;
+      dnsAssertion = ABFS_DNS_PREFIX;
     }
     fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     assertGetFileStatusPath(fs, accountName, dnsAssertion, path);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -561,7 +561,7 @@ public class ITestAzureBlobFileSystemListStatus extends
       configuration.set(FS_DEFAULT_NAME_KEY,
           configuration.get(FS_DEFAULT_NAME_KEY)
               .replace(WASB_DNS_PREFIX, ABFS_DNS_PREFIX));
-      dnsAssertion = WASB_DNS_PREFIX;
+      dnsAssertion = ABFS_DNS_PREFIX;
     }
     fs = (AzureBlobFileSystem) FileSystem.newInstance(configuration);
     assertListStatusPath(fs, accountName, dnsAssertion, path);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -59,11 +59,7 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
 
     String scheme = this.getAuthType() == AuthType.SharedKey ? FileSystemUriSchemes.ABFS_SCHEME
             : FileSystemUriSchemes.ABFS_SECURE_SCHEME;
-    if (fs.getAbfsStore().getAbfsConfiguration().shouldEnableBlobEndPoint()) {
-      if (accountName.contains(ABFS_DNS_PREFIX)) {
-        accountName = accountName.replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
+
     assertEquals(fs.getUri(),
         new URI(scheme,
             filesystem + "@" + accountName,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestSharedKeyAuth.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestSharedKeyAuth.java
@@ -47,11 +47,7 @@ public class ITestSharedKeyAuth extends AbstractAbfsIntegrationTest {
         true);
     AzureBlobFileSystemStore abfsStore = getAbfsStore(getFileSystem());
     String accountName = this.getAccountName();
-    if (abfsStore.getPrefixMode() == PrefixMode.BLOB) {
-      if (abfsStore.getAbfsConfiguration().shouldEnableBlobEndPoint()) {
-        accountName = getAccountName().replace(ABFS_DNS_PREFIX, WASB_DNS_PREFIX);
-      }
-    }
+
     String configkKey = FS_AZURE_ACCOUNT_KEY_PROPERTY_NAME + "." + accountName;
     // a wrong sharedKey
     String secret = "XjUjsGherkDpljuyThd7RpljhR6uhsFjhlxRpmhgD12lnj7lhfRn8kgPt5"

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestBlobOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestBlobOperation.java
@@ -177,13 +177,13 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
                 abfsConfiguration));
 
         String blockId = "block1";
-      byte[] data = new byte[0];
-      Path testPath = path(TEST_PATH);
-      String finalTestPath = testPath.toString()
+        byte[] data = new byte[0];
+        Path testPath = path(TEST_PATH);
+        String finalTestPath = testPath.toString()
           .substring(testPath.toString().lastIndexOf("/"));
 
-      AbfsRestOperation[] op = new AbfsRestOperation[1];
-      Mockito.doAnswer(answer -> {
+        AbfsRestOperation[] op = new AbfsRestOperation[1];
+        Mockito.doAnswer(answer -> {
             AbfsRestOperation answerOp
                 = (AbfsRestOperation) answer.callRealMethod();
             op[0] = answerOp;
@@ -194,18 +194,18 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
               Mockito.any(AppendRequestParameters.class), Mockito.anyList(),
               Mockito.nullable(String.class), Mockito.any(URL.class));
 
-      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
-      String blockId1 = Base64.getEncoder().encodeToString(blockId.getBytes());
-      AppendRequestParameters appendRequestParameters = Mockito.mock(
+        String blockId1 = Base64.getEncoder().encodeToString(blockId.getBytes());
+        AppendRequestParameters appendRequestParameters = Mockito.mock(
           AppendRequestParameters.class);
-      Mockito.doReturn(0).when(appendRequestParameters).getoffset();
-      Mockito.doReturn(0).when(appendRequestParameters).getLength();
-      intercept(IOException.class, () -> {
-        testClient.append(blockId1, finalTestPath, data,
+        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+        Mockito.doReturn(0).when(appendRequestParameters).getLength();
+        intercept(IOException.class, () -> {
+          testClient.append(blockId1, finalTestPath, data,
             appendRequestParameters, null, tracingContext, null);
-      });
+        });
     }
 
     @Test
@@ -234,8 +234,8 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
         Path testPath = path(TEST_PATH);
         String finalTestPath = testPath.toString().substring(testPath.toString().lastIndexOf("/"));
 
-      AbfsRestOperation[] op = new AbfsRestOperation[1];
-      Mockito.doAnswer(answer -> {
+        AbfsRestOperation[] op = new AbfsRestOperation[1];
+        Mockito.doAnswer(answer -> {
             AbfsRestOperation answerOp
                 = (AbfsRestOperation) answer.callRealMethod();
             op[0] = answerOp;
@@ -245,33 +245,33 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
           .getPutBlockOperation(Mockito.any(byte[].class),
               Mockito.any(AppendRequestParameters.class), Mockito.anyList(),
               Mockito.nullable(String.class), Mockito.any(URL.class));
-      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
-      List<String> encodedBlockIds = new ArrayList<>();
-      for (int i = 0; i < blockIds.size(); i++) {
-        String blockId1 = Base64.getEncoder()
+        List<String> encodedBlockIds = new ArrayList<>();
+        for (int i = 0; i < blockIds.size(); i++) {
+          String blockId1 = Base64.getEncoder()
             .encodeToString(blockIds.get(i).getBytes());
-        byte[] data = blockData.get(i);
-        AppendRequestParameters appendRequestParameters = Mockito.mock(
+          byte[] data = blockData.get(i);
+          AppendRequestParameters appendRequestParameters = Mockito.mock(
             AppendRequestParameters.class);
-        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
-        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
-        if (i >= 1) {
-          intercept(IOException.class, () -> {
-            testClient.append(blockId1, finalTestPath, data,
+          Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+          Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+          if (i >= 1) {
+            intercept(IOException.class, () -> {
+              testClient.append(blockId1, finalTestPath, data,
                 appendRequestParameters, null, tracingContext, null);
             encodedBlockIds.add(blockId1);
           });
           Assertions.assertThat(op[0].getResult().getStatusCode())
               .describedAs("The error code is not correct")
               .isEqualTo(HTTP_BAD_REQUEST);
-        } else {
-          testClient.append(blockId1, finalTestPath, data,
+          } else {
+            testClient.append(blockId1, finalTestPath, data,
               appendRequestParameters, null, tracingContext, null);
-          encodedBlockIds.add(blockId1);
+            encodedBlockIds.add(blockId1);
+          }
         }
-      }
     }
 
     @Test
@@ -299,29 +299,29 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
         Path testPath = path(TEST_PATH);
         String finalTestPath = testPath.toString().substring(testPath.toString().lastIndexOf("/"));
 
-      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
-      List<String> encodedBlockIds = new ArrayList<>();
-      for (int i = 0; i < blockIds.size(); i++) {
-        String blockId1 = Base64.getEncoder()
+        List<String> encodedBlockIds = new ArrayList<>();
+        for (int i = 0; i < blockIds.size(); i++) {
+          String blockId1 = Base64.getEncoder()
             .encodeToString(blockIds.get(i).getBytes());
-        byte[] data = blockData.get(i);
-        AppendRequestParameters appendRequestParameters = Mockito.mock(
+          byte[] data = blockData.get(i);
+          AppendRequestParameters appendRequestParameters = Mockito.mock(
             AppendRequestParameters.class);
-        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
-        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
-        testClient.append(blockId1, finalTestPath, data,
+          Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+          Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+          testClient.append(blockId1, finalTestPath, data,
             appendRequestParameters, null, tracingContext, null);
-        encodedBlockIds.add(blockId1);
-      }
-      byte[] bufferString = generateBlockListXml(blockIds).getBytes(
+          encodedBlockIds.add(blockId1);
+        }
+        byte[] bufferString = generateBlockListXml(blockIds).getBytes(
           StandardCharsets.UTF_8);
 
-      tracingContext = Mockito.spy(new TracingContext("abcd",
+        tracingContext = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
-      testClient.flush(bufferString, finalTestPath, false, null, null, null,
+        testClient.flush(bufferString, finalTestPath, false, null, null, null,
           tracingContext);
 
         /* Validates that all blocks are committed and fetched */
@@ -359,32 +359,32 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
         final AbfsUriQueryBuilder abfsUriQueryBuilder = testClient.createDefaultUriQueryBuilder();
         abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCK);
 
-      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
-      List<String> encodedBlockIds = new ArrayList<>();
-      for (int i = 0; i < blockIds.size() - 1; i++) {
-        String blockId1 = Base64.getEncoder()
+        List<String> encodedBlockIds = new ArrayList<>();
+        for (int i = 0; i < blockIds.size() - 1; i++) {
+          String blockId1 = Base64.getEncoder()
             .encodeToString(blockIds.get(i).getBytes());
-        byte[] data = blockData.get(i);
-        AppendRequestParameters appendRequestParameters = Mockito.mock(
+          byte[] data = blockData.get(i);
+          AppendRequestParameters appendRequestParameters = Mockito.mock(
             AppendRequestParameters.class);
-        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
-        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
-        testClient.append(blockId1, finalTestPath, data,
+          Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+          Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+          testClient.append(blockId1, finalTestPath, data,
             appendRequestParameters, null, tracingContext, null);
-        encodedBlockIds.add(blockId1);
-      }
-      byte[] bufferString = generateBlockListXml(blockIds).getBytes(
+          encodedBlockIds.add(blockId1);
+        }
+        byte[] bufferString = generateBlockListXml(blockIds).getBytes(
           StandardCharsets.UTF_8);
 
-      final TracingContext blockListTc = Mockito.spy(new TracingContext("abcd",
+        final TracingContext blockListTc = Mockito.spy(new TracingContext("abcd",
           "abcde", FSOperationType.APPEND,
           TracingHeaderFormat.ALL_ID_FORMAT, null));
 
-      /* Verify that an additional blockId which is not staged if we try to commit, it throws an exception */
-      AbfsRestOperation[] op = new AbfsRestOperation[1];
-      Mockito.doAnswer(answer -> {
+        /* Verify that an additional blockId which is not staged if we try to commit, it throws an exception */
+        AbfsRestOperation[] op = new AbfsRestOperation[1];
+        Mockito.doAnswer(answer -> {
             AbfsRestOperation answerOp
                 = (AbfsRestOperation) answer.callRealMethod();
             op[0] = answerOp;
@@ -394,11 +394,11 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
           .getPutBlockListOperation(Mockito.any(byte[].class),
               Mockito.anyList(), Mockito.nullable(String.class),
               Mockito.any(URL.class));
-      intercept(IOException.class, () -> {
-        testClient.flush(bufferString, finalTestPath, false, null, null, null,
+        intercept(IOException.class, () -> {
+          testClient.flush(bufferString, finalTestPath, false, null, null, null,
             blockListTc);
-      });
-      Assertions.assertThat(op[0].getResult().getStatusCode())
+        });
+        Assertions.assertThat(op[0].getResult().getStatusCode())
           .describedAs("The error code is not correct")
           .isEqualTo(HTTP_BAD_REQUEST);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestBlobOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestBlobOperation.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.fs.azurebfs.AbfsConfiguration;
 import org.apache.hadoop.fs.azurebfs.AbstractAbfsIntegrationTest;
 import org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
+import org.apache.hadoop.fs.azurebfs.contracts.services.AppendRequestParameters;
 import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 import org.apache.hadoop.fs.azurebfs.utils.TracingHeaderFormat;
 import org.assertj.core.api.Assertions;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_CREATED;
@@ -33,9 +35,12 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.BLOCK;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.BLOCKLIST;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.BLOCK_BLOB_TYPE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
+import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.CONTENT_LENGTH;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.CONTENT_MD5;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.CONTENT_TYPE;
+import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.ETAG;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_BLOB_TYPE;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_BLOCKID;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpQueryParams.QUERY_PARAM_COMP;
@@ -221,37 +226,44 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
         final AbfsUriQueryBuilder abfsUriQueryBuilder = testClient.createDefaultUriQueryBuilder();
         abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCK);
 
-        for (int i = 0; i < blockIds.size(); i++) {
-            String blockId1 = Base64.getEncoder().encodeToString(blockIds.get(i).getBytes());
-            abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKID, blockId1);
-            URL url = Mockito.spy(testClient.createRequestUrl(finalTestPath, abfsUriQueryBuilder.toString()));
-            byte[] data = blockData.get(i);
-            requestHeaders.add(new AbfsHttpHeader(CONTENT_LENGTH, String.valueOf(data.length)));
-
-            final AbfsRestOperation op = new AbfsRestOperation(
-                    AbfsRestOperationType.PutBlock,
-                    testClient,
-                    HTTP_METHOD_PUT,
-                    url,
-                    requestHeaders,
-                    data, 0, data.length, null);
-
-            TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
-                    "abcde", FSOperationType.APPEND,
-                    TracingHeaderFormat.ALL_ID_FORMAT, null));
-
-            if (i >= 1) {
-                intercept(IOException.class, () -> op.execute(tracingContext));
-                Assertions.assertThat(op.getResult().getStatusCode())
-                        .describedAs("The status code is incorrect")
-                        .isEqualTo(HTTP_BAD_REQUEST);
-                Assertions.assertThat(op.getResult().getConnResponseMessage())
-                        .describedAs("The exception message is incorrect")
-                        .isEqualTo("The specified blob or block content is invalid.");
-            } else {
-                op.execute(tracingContext);
-            }
+      AbfsRestOperation[] op = new AbfsRestOperation[1];
+      Mockito.doAnswer(answer -> {
+            AbfsRestOperation answerOp
+                = (AbfsRestOperation) answer.callRealMethod();
+            op[0] = answerOp;
+            return answerOp;
+          })
+          .when(testClient)
+          .getPutBlockOperation(Mockito.any(byte[].class),
+              Mockito.any(AppendRequestParameters.class), Mockito.anyList(),
+              Mockito.nullable(String.class), Mockito.any(URL.class));
+      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+          "abcde", FSOperationType.APPEND,
+          TracingHeaderFormat.ALL_ID_FORMAT, null));
+      List<String> encodedBlockIds = new ArrayList<>();
+      for (int i = 0; i < blockIds.size(); i++) {
+        String blockId1 = Base64.getEncoder()
+            .encodeToString(blockIds.get(i).getBytes());
+        byte[] data = blockData.get(i);
+        AppendRequestParameters appendRequestParameters = Mockito.mock(
+            AppendRequestParameters.class);
+        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+        if (i >= 1) {
+          intercept(IOException.class, () -> {
+            testClient.append(blockId1, finalTestPath, data,
+                appendRequestParameters, null, tracingContext, null);
+            encodedBlockIds.add(blockId1);
+          });
+          Assertions.assertThat(op[0].getResult().getStatusCode())
+              .describedAs("The error code is not correct")
+              .isEqualTo(HTTP_BAD_REQUEST);
+        } else {
+          testClient.append(blockId1, finalTestPath, data,
+              appendRequestParameters, null, tracingContext, null);
+          encodedBlockIds.add(blockId1);
         }
+      }
     }
 
     @Test
@@ -278,52 +290,31 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
                 abfsConfiguration));
         Path testPath = path(TEST_PATH);
         String finalTestPath = testPath.toString().substring(testPath.toString().lastIndexOf("/"));
-        final List<AbfsHttpHeader> requestHeaders = ITestAbfsClient.getTestRequestHeaders(testClient);
-        final AbfsUriQueryBuilder abfsUriQueryBuilder = testClient.createDefaultUriQueryBuilder();
-        abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCK);
-        List<String> encodedBlockIds = new ArrayList<>();
-        for (int i = 0; i < blockIds.size(); i++) {
-            String blockId1 = Base64.getEncoder().encodeToString(blockIds.get(i).getBytes());
-            encodedBlockIds.add(blockId1);
-            abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKID, blockId1);
-            URL url = Mockito.spy(testClient.createRequestUrl(finalTestPath, abfsUriQueryBuilder.toString()));
-            byte[] data = blockData.get(i);
-            requestHeaders.add(new AbfsHttpHeader(CONTENT_LENGTH, String.valueOf(data.length)));
 
-            final AbfsRestOperation op = new AbfsRestOperation(
-                    AbfsRestOperationType.PutBlock,
-                    testClient,
-                    HTTP_METHOD_PUT,
-                    url,
-                    requestHeaders,
-                    data, 0, data.length, null);
+      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+          "abcde", FSOperationType.APPEND,
+          TracingHeaderFormat.ALL_ID_FORMAT, null));
+      List<String> encodedBlockIds = new ArrayList<>();
+      for (int i = 0; i < blockIds.size(); i++) {
+        String blockId1 = Base64.getEncoder()
+            .encodeToString(blockIds.get(i).getBytes());
+        byte[] data = blockData.get(i);
+        AppendRequestParameters appendRequestParameters = Mockito.mock(
+            AppendRequestParameters.class);
+        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+        testClient.append(blockId1, finalTestPath, data,
+            appendRequestParameters, null, tracingContext, null);
+        encodedBlockIds.add(blockId1);
+      }
+      byte[] bufferString = generateBlockListXml(blockIds).getBytes(
+          StandardCharsets.UTF_8);
 
-            TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
-                    "abcde", FSOperationType.APPEND,
-                    TracingHeaderFormat.ALL_ID_FORMAT, null));
-
-            op.execute(tracingContext);
-        }
-        byte[] bufferString = generateBlockListXml(blockIds).getBytes(StandardCharsets.UTF_8);
-        final AbfsUriQueryBuilder abfsUriQueryBuilder1 = testClient.createDefaultUriQueryBuilder();
-        final List<AbfsHttpHeader> requestHeaders1 = ITestAbfsClient.getTestRequestHeaders(testClient);
-        abfsUriQueryBuilder1.addQuery(QUERY_PARAM_COMP, BLOCKLIST);
-        requestHeaders1.add(new AbfsHttpHeader(CONTENT_LENGTH, String.valueOf(bufferString.length)));
-        requestHeaders1.add(new AbfsHttpHeader(CONTENT_TYPE, "application/xml"));
-        URL url = Mockito.spy(testClient.createRequestUrl(finalTestPath, abfsUriQueryBuilder1.toString()));
-        final AbfsRestOperation op = new AbfsRestOperation(
-                AbfsRestOperationType.PutBlockList,
-                testClient,
-                HTTP_METHOD_PUT,
-                url,
-                requestHeaders1,
-                bufferString, 0, bufferString.length, null);
-
-        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
-                "abcde", FSOperationType.APPEND,
-                TracingHeaderFormat.ALL_ID_FORMAT, null));
-
-        op.execute(tracingContext);
+      tracingContext = Mockito.spy(new TracingContext("abcd",
+          "abcde", FSOperationType.APPEND,
+          TracingHeaderFormat.ALL_ID_FORMAT, null));
+      testClient.flush(bufferString, finalTestPath, false, null, null, null,
+          tracingContext);
 
         /* Validates that all blocks are committed and fetched */
         AbfsRestOperation op1 = testClient.getBlockList(finalTestPath, tracingContext);
@@ -360,51 +351,48 @@ public class ITestBlobOperation extends AbstractAbfsIntegrationTest {
         final AbfsUriQueryBuilder abfsUriQueryBuilder = testClient.createDefaultUriQueryBuilder();
         abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCK);
 
-        for (int i = 0; i < blockIds.size() - 1; i++) {
-            String blockId1 = Base64.getEncoder().encodeToString(blockIds.get(i).getBytes());
-            abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKID, blockId1);
-            URL url = Mockito.spy(testClient.createRequestUrl(finalTestPath, abfsUriQueryBuilder.toString()));
-            byte[] data = blockData.get(i);
-            requestHeaders.add(new AbfsHttpHeader(CONTENT_LENGTH, String.valueOf(data.length)));
+      TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
+          "abcde", FSOperationType.APPEND,
+          TracingHeaderFormat.ALL_ID_FORMAT, null));
+      List<String> encodedBlockIds = new ArrayList<>();
+      for (int i = 0; i < blockIds.size() - 1; i++) {
+        String blockId1 = Base64.getEncoder()
+            .encodeToString(blockIds.get(i).getBytes());
+        byte[] data = blockData.get(i);
+        AppendRequestParameters appendRequestParameters = Mockito.mock(
+            AppendRequestParameters.class);
+        Mockito.doReturn(0).when(appendRequestParameters).getoffset();
+        Mockito.doReturn(data.length).when(appendRequestParameters).getLength();
+        testClient.append(blockId1, finalTestPath, data,
+            appendRequestParameters, null, tracingContext, null);
+        encodedBlockIds.add(blockId1);
+      }
+      byte[] bufferString = generateBlockListXml(blockIds).getBytes(
+          StandardCharsets.UTF_8);
 
-            final AbfsRestOperation op = new AbfsRestOperation(
-                    AbfsRestOperationType.PutBlock,
-                    testClient,
-                    HTTP_METHOD_PUT,
-                    url,
-                    requestHeaders,
-                    data, 0, data.length, null);
+      final TracingContext blockListTc = Mockito.spy(new TracingContext("abcd",
+          "abcde", FSOperationType.APPEND,
+          TracingHeaderFormat.ALL_ID_FORMAT, null));
 
-            TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
-                    "abcde", FSOperationType.APPEND,
-                    TracingHeaderFormat.ALL_ID_FORMAT, null));
-
-            op.execute(tracingContext);
-        }
-        byte[] bufferString = generateBlockListXml(blockIds).getBytes(StandardCharsets.UTF_8);
-        final AbfsUriQueryBuilder abfsUriQueryBuilder1 = testClient.createDefaultUriQueryBuilder();
-        final List<AbfsHttpHeader> requestHeaders1 = ITestAbfsClient.getTestRequestHeaders(testClient);
-        abfsUriQueryBuilder1.addQuery(QUERY_PARAM_COMP, BLOCKLIST);
-        requestHeaders1.add(new AbfsHttpHeader(CONTENT_LENGTH, String.valueOf(bufferString.length)));
-        requestHeaders1.add(new AbfsHttpHeader(CONTENT_TYPE, "application/xml"));
-        URL url = Mockito.spy(testClient.createRequestUrl(finalTestPath, abfsUriQueryBuilder1.toString()));
-        final AbfsRestOperation op = new AbfsRestOperation(
-                AbfsRestOperationType.PutBlockList,
-                testClient,
-                HTTP_METHOD_PUT,
-                url,
-                requestHeaders1,
-                bufferString, 0, bufferString.length, null);
-
-        TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
-                "abcde", FSOperationType.APPEND,
-                TracingHeaderFormat.ALL_ID_FORMAT, null));
-
-        /* Verify that an additional blockId which is not staged if we try to commit, it throws an exception */
-        intercept(IOException.class, () -> op.execute(tracingContext));
-        Assertions.assertThat(op.getResult().getStatusCode())
-                .describedAs("The error code is not correct")
-                .isEqualTo(HTTP_BAD_REQUEST);
+      /* Verify that an additional blockId which is not staged if we try to commit, it throws an exception */
+      AbfsRestOperation[] op = new AbfsRestOperation[1];
+      Mockito.doAnswer(answer -> {
+            AbfsRestOperation answerOp
+                = (AbfsRestOperation) answer.callRealMethod();
+            op[0] = answerOp;
+            return answerOp;
+          })
+          .when(testClient)
+          .getPutBlockListOperation(Mockito.any(byte[].class),
+              Mockito.anyList(), Mockito.nullable(String.class),
+              Mockito.any(URL.class));
+      intercept(IOException.class, () -> {
+        testClient.flush(bufferString, finalTestPath, false, null, null, null,
+            blockListTc);
+      });
+      Assertions.assertThat(op[0].getResult().getStatusCode())
+          .describedAs("The error code is not correct")
+          .isEqualTo(HTTP_BAD_REQUEST);
     }
 
     /*


### PR DESCRIPTION
The uri in fs and store is changed from the one given in config to something else if enbaleBlob is set true. for ex:
container@account.dfs.core.windows.net to container@account.blob.core.windows.net

This is not required to flow in correct uri to client. Reason being a given method in AbfsClient will either call dfs endpoint or blob endpoint. No method will be such that it can call both endpoint and need hook from fs to call the required endpoint. If a method has to call dfs endpoint, it will always call that. Similarly, any method calling blob endpoint, will always call blob endpoint.

Change in pr:
1. the uri that flows throught fs and store to client will be what is given in config.
2. If a method is not compatible with the uri, it will change that via `changePrefixFromBlobtoDfs` or `changePrefixFromDfsToBlob` method. 
3. The prefixMode is set in the fs. Store uses prefixMode is decide if it has to carry out an operation for dfs or blob. And as per the flow it calls endpoint relevant methods in client.


What will a be major change:
1. The path in the fileStatus object will have the endpoint as given in uri of config. If its container@account.dfs.core.windows.net
    - fs.getFileStatus("/path) or fs.getFileStatus("container@account.dfs.core.windows.net/path") or fs.getFileStatus("container@account.blob.core.windows.net/path") will give filestatus obj having path `abfs://container@account.dfs.core.windows.net/path`.
    - similar for listStatus, remoteListStatusIterator.


-----------------------------------------
------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:276->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=119).
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 792, Failures: 1, Errors: 1, Skipped: 197
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testValidateSeekBounds:276->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=29).
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 792, Failures: 1, Errors: 1, Skipped: 197
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 792, Failures: 0, Errors: 0, Skipped: 291
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[WARNING] Tests run: 141, Failures: 0, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 792, Failures: 0, Errors: 0, Skipped: 291
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 45

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:366 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 792, Failures: 0, Errors: 1, Skipped: 197
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49


```
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit 7fad0940a85f033387d170078e2fa91456e944c7 (HEAD -> noUriChange, origin/noUriChange)
Author: Pranav Saxena <pranavsaxena@microsoft.com>
Date:   Tue Aug 1 04:11:38 2023 -0700

    indentation in ITestBlobOperation
```