### PR TITLE
Lock fix

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsHttpOperation.java
@@ -145,7 +145,7 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
   protected AbfsHttpOperation(final URL url,
       final String method,
       final int httpStatus) {
-    this.isTraceEnabled = LOG.isTraceEnabled();
+    this.isTraceEnabled = true;
     this.url = url;
     this.method = method;
     this.statusCode = httpStatus;
@@ -328,7 +328,7 @@ public class AbfsHttpOperation implements AbfsPerfLoggable {
    */
   public AbfsHttpOperation(final URL url, final String method, final List<AbfsHttpHeader> requestHeaders)
       throws IOException {
-    this.isTraceEnabled = LOG.isTraceEnabled();
+    this.isTraceEnabled = true;
     this.url = url;
     this.method = method;
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -479,7 +479,7 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
                   mapLock.lock();
                   if (!getMap().containsKey(key)) {
                     throw new Exception("Block is missing with blockId " + blockToUpload.getBlockId() +
-                            " for offset " + offset + " for path" + path);
+                            " for offset " + offset + " for path" + path  + " with streamId " + outputStreamId);
                   } else {
                     map.put(blockToUpload.getBlockId(), BlockStatus.SUCCESS);
                   }
@@ -872,20 +872,20 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
             break;
           } else {
             if (!entry.getKey().equals(orderedBlockList.get(mapEntry))) {
-              LOG.debug("The order for the given offset {} with blockId {} " +
-                      " for the path {} was not successful", offset, entry.getKey(), path);
+              LOG.debug("The order for the given offset {} with blockId {} and streamId {} " +
+                      " for the path {} was not successful", offset, entry.getKey(), outputStreamId, path);
               throw new IOException("The ordering in map is incorrect for blockId " +
-                      entry.getKey() + " and offset " + offset + " for path" + path);
+                      entry.getKey() + " and offset " + offset + " for path" + path + " with streamId " + outputStreamId);
             }
             blockIdList.add(entry.getKey());
             mapEntry++;
           }
         }
         if (!successValue) {
-          LOG.debug("A past append for the given offset {} with blockId {} " +
-                  " for the path {} was not successful", offset, failedBlockId, path);
+          LOG.debug("A past append for the given offset {} with blockId {} and streamId {}" +
+                  " for the path {} was not successful", offset, failedBlockId, outputStreamId, path);
           throw new IOException("A past append was not successful for blockId " +
-                  failedBlockId + " and offset " + offset + " for path" + path);
+                  failedBlockId + " and offset " + offset + " for path" + path + " with streamId " + outputStreamId);
         }
         // Generate the xml with the list of blockId's to generate putBlockList call.
         String blockListXml = generateBlockListXml(blockIdList);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -887,8 +887,13 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
         op = client.flush(blockListXml.getBytes(), path,
                 isClose, cachedSasToken.get(), leaseId, getETag(), new TracingContext(tracingContext));
         setETag(op.getResult().getResponseHeader(HttpHeaderConfigurations.ETAG));
-        getMap().clear();
-        orderedBlockList.clear();
+        try {
+          mapLock.lock();
+          getMap().clear();
+          orderedBlockList.clear();
+        } finally {
+          mapLock.unlock();
+        }
       } else {
         LOG.debug("Flush over DFS for ingress config value {} for path {} ",
                 client.getAbfsConfiguration().shouldIngressFallbackToDfs(), path);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsOutputStream.java
@@ -478,7 +478,8 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
                 try {
                   mapLock.lock();
                   if (!getMap().containsKey(key)) {
-                    throw new Exception("Block is missing with blockId " + blockToUpload.getBlockId() + " for offset " + offset + " for path" + path);
+                    throw new Exception("Block is missing with blockId " + blockToUpload.getBlockId() +
+                            " for offset " + offset + " for path" + path);
                   } else {
                     map.put(blockToUpload.getBlockId(), BlockStatus.SUCCESS);
                   }
@@ -888,8 +889,10 @@ public class AbfsOutputStream extends OutputStream implements Syncable,
         }
         // Generate the xml with the list of blockId's to generate putBlockList call.
         String blockListXml = generateBlockListXml(blockIdList);
+        TracingContext tracingContextBlobFlush = new TracingContext(tracingContext);
+        tracingContextBlobFlush.setFallbackDFSAppend("B " + position);
         op = client.flush(blockListXml.getBytes(), path,
-                isClose, cachedSasToken.get(), leaseId, getETag(), new TracingContext(tracingContext));
+                isClose, cachedSasToken.get(), leaseId, getETag(), tracingContextBlobFlush);
         setETag(op.getResult().getResponseHeader(HttpHeaderConfigurations.ETAG));
         try {
           mapLock.lock();


### PR DESCRIPTION
The actual problem statement was that for same blockId we were seeing successful putBlockRequests and simultaneously exception coming from map that the entry is not found in the MAP.
Fixed it by correcting locking for containsKey()