### PR TITLE
Fixing Behavior of FS APIs on Root Operation

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -494,6 +494,15 @@ public class AzureBlobFileSystem extends FileSystem
       final Progressable progress) throws IOException {
 
     statIncrement(CALL_CREATE_NON_RECURSIVE);
+
+    if (f.isRoot()) {
+      // Throwing same exception as create() on root.
+      throw new AbfsRestOperationException(HTTP_CONFLICT,
+          AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
+          PATH_EXISTS,
+          null);
+    }
+
     final Path parent = f.getParent();
     TracingContext tracingContext = new TracingContext(clientCorrelationId,
         fileSystemId, FSOperationType.CREATE_NON_RECURSIVE, tracingHeaderFormat,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1373,8 +1373,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
       if (isDirectory) {
         throw new AbfsRestOperationException(
-                AzureServiceErrorCode.PATH_NOT_FOUND.getStatusCode(),
-                AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
+                AzureServiceErrorCode.PATH_CONFLICT.getStatusCode(),
+                AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
                 "openFileForRead must be used with files and not directories." +
                         "Attempt made for read on explicit directory.",
                 null);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1373,8 +1373,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
       if (isDirectory) {
         throw new AbfsRestOperationException(
-                AzureServiceErrorCode.PATH_CONFLICT.getStatusCode(),
-                AzureServiceErrorCode.PATH_CONFLICT.getErrorCode(),
+                AzureServiceErrorCode.PATH_NOT_FOUND.getStatusCode(),
+                AzureServiceErrorCode.PATH_NOT_FOUND.getErrorCode(),
                 "openFileForRead must be used with files and not directories." +
                         "Attempt made for read on explicit directory.",
                 null);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -943,7 +943,7 @@ public class ITestAzureBlobFileSystemCreate extends
     Path testFile = new Path("/");
     try {
       fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
-      fail("Should've thrown");
+      fail("Should've thrown AbfsRestOperationException with HTTP_CONFLICT");
     } catch (AbfsRestOperationException e) {
       assertEquals(e.getStatusCode(), HTTP_CONFLICT);
     }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -936,6 +936,20 @@ public class ITestAzureBlobFileSystemCreate extends
   }
 
   @Test
+  @SuppressWarnings("deprecation")
+  public void testCreateNonRecursiveOnRoot() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+
+    Path testFile = new Path("/");
+    try {
+      fs.createNonRecursive(testFile, FsPermission.getDefault(), false, 1024, (short) 1, 1024, null);
+      fail("Should've thrown");
+    } catch (AbfsRestOperationException e) {
+      assertEquals(e.getStatusCode(), HTTP_CONFLICT);
+    }
+  }
+
+  @Test
   public void testCreateNonRecursiveForAtomicDirectoryFile() throws Exception {
     AzureBlobFileSystem fileSystem = getFileSystem();
     Assume.assumeTrue(


### PR DESCRIPTION
createNonRecursive() on root path: Currently fails with NPE. Should fail with 409 for root path.