### PR TITLE
rename / deletion parallel exec have child tc

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsLease.java
@@ -174,7 +174,7 @@ public abstract class AbfsLease {
             LOG.debug("Failed to acquire lease on {}, retrying: {}", path, throwable);
             acquireRetryCount++;
             acquireLease(retryPolicy, numRetries + 1, retryInterval,
-                retryInterval, tracingContext);
+                retryInterval, new TracingContext(tracingContext));
           } else {
             exception = throwable;
           }
@@ -191,7 +191,7 @@ public abstract class AbfsLease {
       @Override
       public void run() {
         try {
-          leaseID.set(callRenewLeaseAPI(path, leaseID.get(), tracingContext));
+          leaseID.set(callRenewLeaseAPI(path, leaseID.get(), new TracingContext(tracingContext)));
         } catch (AzureBlobFileSystemException ignored) {
         }
       }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/ListBlobProducer.java
@@ -88,7 +88,8 @@ public class ListBlobProducer {
         }
         AbfsRestOperation op = null;
         try {
-          op = client.getListBlobs(nextMarker, src, null, maxResult, tracingContext);
+          op = client.getListBlobs(nextMarker, src, null, maxResult,
+              new TracingContext(tracingContext));
         } catch (AzureBlobFileSystemException ex) {
           listBlobQueue.setFailed(ex);
           return;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -601,7 +602,7 @@ public class ITestAzureBlobFileSystemDelete extends
     fs.create(new Path("/testDir/file1"));
     fs.create(new Path("/testDir/file2"));
 
-    Set<TracingContext> tracingContextSet = new HashSet<>();
+    Set<TracingContext> tracingContextSet = ConcurrentHashMap.newKeySet();
     Mockito.doAnswer(answer -> {
           TracingContext tracingContext = answer.getArgument(2);
           Assertions.assertThat(tracingContextSet).doesNotContain(tracingContext);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -1669,10 +1669,14 @@ public class ITestAzureBlobFileSystemRename extends
         .getClient()
         .deleteBlobPath(new Path("/src"), null, Mockito.mock(TracingContext.class));
     Boolean srcBlobNotFoundExReceived = false;
+    TracingContext tracingContext = new TracingContext("clientCorrelationId",
+        "fileSystemId", FSOperationType.TEST_OP,
+        getConfiguration().getTracingHeaderFormat(),
+        null);
     try {
       fs.getAbfsStore()
           .copyBlob(new Path("/src"), new Path("/dst"),
-              null, Mockito.mock(TracingContext.class));
+              null, tracingContext);
     } catch (AbfsRestOperationException ex) {
       if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
         srcBlobNotFoundExReceived = true;


### PR DESCRIPTION
All the parallel threads in rename and delete dir should have diff tc objects. Why?
1. header creation is not synchronized, so, if mutiple threads want to create header at same time, it will corrupt the header string for all the threads using same tc object at that instance
2. TC obj is expected to have lifetime until server call is made. Post that, it should not be reused.


------------------------
:::: AGGREGATED TEST RESULT ::::

HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsPerfTracker.verifyTrackingForAggregateLatencyRecords:155 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:22:51.057Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 ls=0 lc=42 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=42 s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[ERROR]   TestAbfsPerfTracker.verifyTrackingForSingletonLatencyRecords:115 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:22:55.817Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[INFO]
[ERROR] Tests run: 141, Failures: 2, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAzureBlobFileSystemRandomRead.testSkipBounds:225->Assert.assertTrue:42->Assert.fail:89 There should not be any network I/O (elapsedTimeMs=48).
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 795, Failures: 1, Errors: 1, Skipped: 199
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49

HNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 9 is not within the expected range: [5.60, 8.40].
[ERROR]   TestAbfsPerfTracker.verifyTrackingForAggregateLatencyRecords:155 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:31:11.253Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 ls=0 lc=42 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=42 s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[ERROR]   TestAbfsPerfTracker.verifyTrackingForSingletonLatencyRecords:115 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:31:16.176Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[INFO]
[ERROR] Tests run: 141, Failures: 3, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 795, Failures: 0, Errors: 1, Skipped: 199
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsPerfTracker.verifyTrackingForAggregateLatencyRecords:155 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:39:25.437Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 ls=0 lc=42 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=42 s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[ERROR]   TestAbfsPerfTracker.verifyTrackingForSingletonLatencyRecords:115 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:39:31.285Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[INFO]
[ERROR] Tests run: 141, Failures: 2, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 795, Failures: 0, Errors: 0, Skipped: 275
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 45

NonHNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsPerfTracker.verifyTrackingForAggregateLatencyRecords:155 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:49:28.398Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=1 ls=1 lc=42 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=42 s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[ERROR]   TestAbfsPerfTracker.verifyTrackingForSingletonLatencyRecords:115 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:49:32.475Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[INFO]
[ERROR] Tests run: 141, Failures: 2, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 795, Failures: 0, Errors: 0, Skipped: 275
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 45

AppendBlob-HNS-OAuth
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestAbfsPerfTracker.verifyTrackingForAggregateLatencyRecords:155 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:59:26.432Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 ls=0 lc=42 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ ls=[0-9]+ lc=42 s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[ERROR]   TestAbfsPerfTracker.verifyTrackingForSingletonLatencyRecords:115 [Latency record should be in the correct format]
Expecting:
  "h=hadoop-vm-east2.internal.cloudapp.net t=2023-08-16T05:59:30.206Z a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=0 s=0 e= ci=null ri= ct=0 st=0 rt=0 bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
to contain pattern:
  "h=[^ ]* t=[^ ]* a=bogusFilesystemName c=bogusAccountName cr=oneOperationCaller ce=oneOperationCallee r=Succeeded l=[0-9]+ s=0 e= ci=[^ ]* ri=[^ ]* bs=0 br=0 m=GET u=http%3A%2F%2Fwww.microsoft.com%2FbogusFile"
[INFO]
[ERROR] Tests run: 141, Failures: 2, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ITestAbfsListStatusRemoteIterator.testWithAbfsIteratorDisabled:173 [After removing every iterm found from the iterator, there should be no more elements in the fileNames] expected:<[0]> but was:<[1]>
[ERROR] Errors:
[ERROR]   ITestAzureBlobFileSystemLease.testAcquireRetry:383 » TestTimedOut test timed o...
[INFO]
[ERROR] Tests run: 795, Failures: 1, Errors: 1, Skipped: 199
[INFO] Results:
[INFO]
[WARNING] Tests run: 284, Failures: 0, Errors: 0, Skipped: 49

Time taken: 46 mins 45 secs.


```
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit 7fc4cb0db13fa4f11b2a52cbe576406ecfe7c6b8 (HEAD -> ABFS_3.3.2_dev_parallel_tc, origin/ABFS_3.3.2_dev_parallel_tc)
Author: Pranav Saxena <pranavsaxena@microsoft.com>
Date:   Tue Aug 15 22:05:10 2023 -0700

    fix NPE due to child obj creation of mocked obj; assertion in ITestListBlobProducer to check if all tc going ahead are diff;
```

