### PR TITLE
List tracing context fix parallelop

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2313,6 +2313,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
           if (!shouldContinue) {
             perfInfo.registerAggregates(startAggregate, countAggregate);
+          } else {
+            tracingContext = new TracingContext(tracingContext);
           }
         }
       } while (shouldContinue);
@@ -2391,6 +2393,8 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
         if (!shouldContinue) {
           perfInfo.registerAggregates(startAggregate, countAggregate);
+        } else {
+          tracingContext = new TracingContext(tracingContext);
         }
       }
     } while (shouldContinue);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -2313,8 +2313,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
           if (!shouldContinue) {
             perfInfo.registerAggregates(startAggregate, countAggregate);
-          } else {
-            tracingContext = new TracingContext(tracingContext);
           }
         }
       } while (shouldContinue);
@@ -2393,8 +2391,6 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
 
         if (!shouldContinue) {
           perfInfo.registerAggregates(startAggregate, countAggregate);
-        } else {
-          tracingContext = new TracingContext(tracingContext);
         }
       }
     } while (shouldContinue);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1663,13 +1663,13 @@ public class AbfsClient implements Closeable {
   }
 
   AbfsRestOperation getAbfsRestOperation(final AbfsRestOperationType operationType,
-      final String httpMethodGet,
+      final String httpMethod,
       final URL url,
       final List<AbfsHttpHeader> requestHeaders) {
     return new AbfsRestOperation(
         operationType,
         this,
-        httpMethodGet,
+        httpMethod,
         url,
         requestHeaders
     );

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -284,12 +284,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.CreateFileSystem,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.CreateFileSystem, HTTP_METHOD_PUT, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -311,11 +308,8 @@ public class AbfsClient implements Closeable {
         SASTokenProvider.CREATE_CONTAINER_OPERATION, abfsUriQueryBuilder);
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.CreateContainer,
-        this,
-        HTTP_METHOD_PUT,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.CreateContainer, HTTP_METHOD_PUT, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -338,12 +332,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.SetFileSystemProperties,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetFileSystemProperties, HTTP_METHOD_PUT, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -366,12 +357,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.ListPaths,
-            this,
-            HTTP_METHOD_GET,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.ListPaths, HTTP_METHOD_GET, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -386,12 +373,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.GetFileSystemProperties,
-            this,
-            HTTP_METHOD_HEAD,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetFileSystemProperties, HTTP_METHOD_HEAD, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -406,12 +390,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.DeleteFileSystem,
-            this,
-            HTTP_METHOD_DELETE,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.DeleteFileSystem, HTTP_METHOD_DELETE, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -433,11 +414,8 @@ public class AbfsClient implements Closeable {
         SASTokenProvider.DELETE_CONTAINER_OPERATION, abfsUriQueryBuilder);
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.DeleteContainer,
-        this,
-        HTTP_METHOD_DELETE,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.DeleteContainer, HTTP_METHOD_DELETE, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -482,12 +460,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.CreatePath,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.CreatePath, HTTP_METHOD_PUT, url, requestHeaders);
     try {
       op.execute(tracingContext);
     } catch (AzureBlobFileSystemException ex) {
@@ -533,12 +507,8 @@ public class AbfsClient implements Closeable {
     }
     requestHeaders.add(new AbfsHttpHeader(CONTENT_LENGTH, ZERO));
     requestHeaders.add(new AbfsHttpHeader(X_MS_BLOB_TYPE, BLOCK_BLOB_TYPE));
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.PutBlob,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.PutBlob, HTTP_METHOD_PUT, url, requestHeaders);
     try {
       op.execute(tracingContext);
     } catch (AzureBlobFileSystemException ex) {
@@ -574,12 +544,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeasePath,
-        this,
-        HTTP_METHOD_POST,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeasePath, HTTP_METHOD_POST, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -596,12 +562,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(path, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeaseBlob,
-        this,
-        HTTP_METHOD_PUT,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeaseBlob, HTTP_METHOD_PUT, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -619,12 +581,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeasePath,
-        this,
-        HTTP_METHOD_POST,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeasePath, HTTP_METHOD_POST, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -642,12 +600,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(path, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeaseBlob,
-        this,
-        HTTP_METHOD_PUT,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeaseBlob, HTTP_METHOD_PUT, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -665,12 +619,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeasePath,
-        this,
-        HTTP_METHOD_POST,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeasePath, HTTP_METHOD_POST, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -688,12 +638,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(path, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeasePath,
-        this,
-        HTTP_METHOD_PUT,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeasePath, HTTP_METHOD_PUT, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -711,12 +657,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.LeasePath,
-        this,
-        HTTP_METHOD_POST,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.LeasePath, HTTP_METHOD_POST, url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -745,12 +687,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.RenamePath,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.RenamePath, HTTP_METHOD_PUT, url, requestHeaders);
     // no attempt at recovery using timestamps as it was not reliable.
     op.execute(tracingContext);
     return op;
@@ -912,15 +850,9 @@ public class AbfsClient implements Closeable {
       final List<AbfsHttpHeader> requestHeaders,
       final String sasTokenForReuse,
       final URL url) {
-    return new AbfsRestOperation(
-        AbfsRestOperationType.PutBlock,
-        this,
-        HTTP_METHOD_PUT,
+    return getAbfsRestOperation(AbfsRestOperationType.PutBlock, HTTP_METHOD_PUT,
         url,
-        requestHeaders,
-        buffer,
-        reqParams.getoffset(),
-        reqParams.getLength(),
+        requestHeaders, buffer, reqParams.getoffset(), reqParams.getLength(),
         sasTokenForReuse);
   }
 
@@ -967,14 +899,8 @@ public class AbfsClient implements Closeable {
       final List<AbfsHttpHeader> requestHeaders,
       final String sasTokenForReuse,
       final URL url) {
-    return new AbfsRestOperation(
-        AbfsRestOperationType.PutBlockList,
-        this,
-        HTTP_METHOD_PUT,
-        url,
-        requestHeaders, buffer,
-        0,
-        buffer.length,
+    return getAbfsRestOperation(AbfsRestOperationType.PutBlockList,
+        HTTP_METHOD_PUT, url, requestHeaders, buffer, 0, buffer.length,
         sasTokenForReuse);
   }
 
@@ -999,15 +925,8 @@ public class AbfsClient implements Closeable {
       final int bufferOffset,
       final int bufferLength,
       final String sasTokenForReuse) {
-    return new AbfsRestOperation(
-        operationType,
-        this,
-        httpMethod,
-        url,
-        requestHeaders,
-        buffer,
-        bufferOffset,
-        bufferLength, sasTokenForReuse);
+    return getAbfsRestOperation(operationType, httpMethod, url, requestHeaders,
+        buffer, bufferOffset, bufferLength, sasTokenForReuse);
   }
 
   /**
@@ -1082,12 +1001,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.Flush,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders, sasTokenForReuse);
+    final AbfsRestOperation op = getAbfsRestOperation(requestHeaders,
+        sasTokenForReuse, url, AbfsRestOperationType.Flush, HTTP_METHOD_PUT);
     op.execute(tracingContext);
     return op;
   }
@@ -1112,12 +1027,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.SetPathProperties,
-            this,
-            HTTP_METHOD_PUT,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetPathProperties, HTTP_METHOD_PUT, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -1144,12 +1056,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.GetPathStatus,
-            this,
-            HTTP_METHOD_HEAD,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetPathStatus, HTTP_METHOD_HEAD, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -1172,12 +1081,9 @@ public class AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKLISTTYPE, COMMITTED);
     final URL url = createBlobRequestUrl(path, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.GetBlockList,
-            this,
-            HTTP_METHOD_GET,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetBlockList, HTTP_METHOD_GET, url,
+        requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -1209,15 +1115,9 @@ public class AbfsClient implements Closeable {
       }
       opType = AbfsRestOperationType.ReadFile;
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            opType,
-            this,
-            HTTP_METHOD_GET,
-            url,
-            requestHeaders,
-            buffer,
-            bufferOffset,
-            bufferLength, sasTokenForReuse);
+    final AbfsRestOperation op = getAbfsRestOperation(opType, HTTP_METHOD_GET,
+        url, requestHeaders, buffer, bufferOffset, bufferLength,
+        sasTokenForReuse);
     op.execute(tracingContext);
 
     return op;
@@ -1238,12 +1138,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-            AbfsRestOperationType.DeletePath,
-            this,
-            HTTP_METHOD_DELETE,
-            url,
-            requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.DeletePath, HTTP_METHOD_DELETE, url,
+        requestHeaders);
     try {
     op.execute(tracingContext);
     } catch (AzureBlobFileSystemException e) {
@@ -1287,11 +1184,8 @@ public class AbfsClient implements Closeable {
         && DEFAULT_DELETE_CONSIDERED_IDEMPOTENT) {
       // Server has returned HTTP 404, which means path no longer
       // exists. Assuming delete result to be idempotent, return success.
-      final AbfsRestOperation successOp = new AbfsRestOperation(
-          AbfsRestOperationType.DeletePath,
-          this,
-          HTTP_METHOD_DELETE,
-          op.getUrl(),
+      final AbfsRestOperation successOp = getAbfsRestOperation(
+          AbfsRestOperationType.DeletePath, HTTP_METHOD_DELETE, op.getUrl(),
           op.getRequestHeaders());
       successOp.hardSetResult(HttpURLConnection.HTTP_OK);
       LOG.debug("Returning success response from delete idempotency logic");
@@ -1325,11 +1219,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.SetOwner,
-        this,
-        AbfsHttpConstants.HTTP_METHOD_PUT,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetOwner, AbfsHttpConstants.HTTP_METHOD_PUT, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1354,12 +1245,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.SetPermissions,
-        this,
-        AbfsHttpConstants.HTTP_METHOD_PUT,
-        url,
-        requestHeaders);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetPermissions, AbfsHttpConstants.HTTP_METHOD_PUT,
+        url, requestHeaders);
     op.execute(tracingContext);
     return op;
   }
@@ -1392,11 +1280,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.SetAcl,
-        this,
-        AbfsHttpConstants.HTTP_METHOD_PUT,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetAcl, AbfsHttpConstants.HTTP_METHOD_PUT, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1420,11 +1305,8 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetAcl,
-        this,
-        AbfsHttpConstants.HTTP_METHOD_HEAD,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetAcl, AbfsHttpConstants.HTTP_METHOD_HEAD, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1452,9 +1334,9 @@ public class AbfsClient implements Closeable {
       url = changePrefixFromBlobtoDfs(url);
     }
 
-    AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.CheckAccess, this,
-        AbfsHttpConstants.HTTP_METHOD_HEAD, url, createDefaultHeaders());
+    AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.CheckAccess, AbfsHttpConstants.HTTP_METHOD_HEAD,
+        url, createDefaultHeaders());
     op.execute(tracingContext);
     return op;
   }
@@ -1507,24 +1389,15 @@ public class AbfsClient implements Closeable {
   @VisibleForTesting
   AbfsRestOperation getCopyBlobOperation(final URL url,
       final List<AbfsHttpHeader> requestHeaders) {
-    return new AbfsRestOperation(
-        AbfsRestOperationType.CopyBlob,
-        this,
-        HTTP_METHOD_PUT,
-        url,
-        requestHeaders);
+    return getAbfsRestOperation(AbfsRestOperationType.CopyBlob, HTTP_METHOD_PUT,
+        url, requestHeaders);
   }
 
   @VisibleForTesting
   AbfsRestOperation getListBlobOperation(final URL url,
       final List<AbfsHttpHeader> requestHeaders) {
-    return new AbfsRestOperation(
-        AbfsRestOperationType.GetListBlobProperties,
-        this,
-        HTTP_METHOD_GET,
-        url,
-        requestHeaders
-    );
+    return getAbfsRestOperation(AbfsRestOperationType.GetListBlobProperties,
+        HTTP_METHOD_GET, url, requestHeaders);
   }
 
   /**
@@ -1540,11 +1413,8 @@ public class AbfsClient implements Closeable {
         SASTokenProvider.GET_BLOB_PROPERTIES_OPERATION, abfsUriQueryBuilder);
     final URL url = createBlobRequestUrl(blobRelativePath, abfsUriQueryBuilder);
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetBlobProperties,
-        this,
-        HTTP_METHOD_HEAD,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetBlobProperties, HTTP_METHOD_HEAD, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1567,11 +1437,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetContainerProperties,
-        this,
-        HTTP_METHOD_HEAD,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetContainerProperties, HTTP_METHOD_HEAD, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1596,11 +1463,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(blobRelativePath, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetBlobMetadata,
-        this,
-        HTTP_METHOD_HEAD,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetBlobMetadata, HTTP_METHOD_HEAD, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1630,11 +1494,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(blobRelativePath, abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.SetBlobMetadata,
-        this,
-        HTTP_METHOD_PUT,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetBlobMetadata, HTTP_METHOD_PUT, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1660,11 +1521,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetContainerMetadata,
-        this,
-        HTTP_METHOD_HEAD,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.GetContainerMetadata, HTTP_METHOD_HEAD, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1694,11 +1552,8 @@ public class AbfsClient implements Closeable {
 
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
 
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.SetContainerMetadata,
-        this,
-        HTTP_METHOD_PUT,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.SetContainerMetadata, HTTP_METHOD_PUT, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
@@ -1779,14 +1634,57 @@ public class AbfsClient implements Closeable {
     if(leaseId != null) {
       requestHeaders.add(new AbfsHttpHeader(X_MS_LEASE_ID, leaseId));
     }
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.DeleteBlob,
-        this,
-        HTTP_METHOD_DELETE,
-        url,
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.DeleteBlob, HTTP_METHOD_DELETE, url,
         requestHeaders);
     op.execute(tracingContext);
     return op;
+  }
+
+  AbfsRestOperation getAbfsRestOperation(final AbfsRestOperationType operationType,
+      final String httpMethod,
+      final URL url,
+      final List<AbfsHttpHeader> requestHeaders,
+      final byte[] buffer,
+      final int bufferOffset,
+      final int bufferLength,
+      final String sasTokenForReuse) {
+    return new AbfsRestOperation(
+        operationType,
+        this,
+        httpMethod,
+        url,
+        requestHeaders,
+        buffer,
+        bufferOffset,
+        bufferLength,
+        sasTokenForReuse);
+  }
+
+  AbfsRestOperation getAbfsRestOperation(final AbfsRestOperationType operationType,
+      final String httpMethodGet,
+      final URL url,
+      final List<AbfsHttpHeader> requestHeaders) {
+    return new AbfsRestOperation(
+        operationType,
+        this,
+        httpMethodGet,
+        url,
+        requestHeaders
+    );
+  }
+
+  AbfsRestOperation getAbfsRestOperation(final List<AbfsHttpHeader> requestHeaders,
+      final String sasTokenForReuse,
+      final URL url,
+      final AbfsRestOperationType operationType,
+      final String httpMethod) {
+    return new AbfsRestOperation(
+        operationType,
+        this,
+        httpMethod,
+        url,
+        requestHeaders, sasTokenForReuse);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1001,8 +1001,9 @@ public class AbfsClient implements Closeable {
     if (url.toString().contains(WASB_DNS_PREFIX)) {
       url = changePrefixFromBlobtoDfs(url);
     }
-    final AbfsRestOperation op = getAbfsRestOperation(requestHeaders,
-        sasTokenForReuse, url, AbfsRestOperationType.Flush, HTTP_METHOD_PUT);
+    final AbfsRestOperation op = getAbfsRestOperation(
+        AbfsRestOperationType.Flush, HTTP_METHOD_PUT, url, requestHeaders,
+        sasTokenForReuse);
     op.execute(tracingContext);
     return op;
   }
@@ -1674,11 +1675,11 @@ public class AbfsClient implements Closeable {
     );
   }
 
-  AbfsRestOperation getAbfsRestOperation(final List<AbfsHttpHeader> requestHeaders,
-      final String sasTokenForReuse,
+  AbfsRestOperation getAbfsRestOperation(final AbfsRestOperationType operationType,
+      final String httpMethod,
       final URL url,
-      final AbfsRestOperationType operationType,
-      final String httpMethod) {
+      final List<AbfsHttpHeader> requestHeaders,
+      final String sasTokenForReuse) {
     return new AbfsRestOperation(
         operationType,
         this,

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsClient.java
@@ -1515,6 +1515,18 @@ public class AbfsClient implements Closeable {
         requestHeaders);
   }
 
+  @VisibleForTesting
+  AbfsRestOperation getListBlobOperation(final URL url,
+      final List<AbfsHttpHeader> requestHeaders) {
+    return new AbfsRestOperation(
+        AbfsRestOperationType.GetListBlobProperties,
+        this,
+        HTTP_METHOD_GET,
+        url,
+        requestHeaders
+    );
+  }
+
   /**
    * @return the blob properties returned from server.
    * @throws AzureBlobFileSystemException in case it is not a 404 error or some other exception
@@ -1738,13 +1750,8 @@ public class AbfsClient implements Closeable {
         abfsUriQueryBuilder);
     final URL url = createBlobRequestUrl(abfsUriQueryBuilder);
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
-    final AbfsRestOperation op = new AbfsRestOperation(
-        AbfsRestOperationType.GetListBlobProperties,
-        this,
-        HTTP_METHOD_GET,
-        url,
-        requestHeaders
-    );
+    final AbfsRestOperation op = getListBlobOperation(url, requestHeaders);
+
     op.execute(tracingContext);
     return op;
   }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.fs.azurebfs.AbfsStatistic;
 import org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -219,7 +219,7 @@ public class AbfsRestOperation {
    * HTTP operations.
    * @param tracingContext TracingContext instance to track correlation IDs
    */
-  private void completeExecute(TracingContext tracingContext)
+  void completeExecute(TracingContext tracingContext)
       throws AzureBlobFileSystemException {
     // see if we have latency reports from the previous requests
     String latencyHeader = getClientLatency();

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperation.java
@@ -198,10 +198,14 @@ public class AbfsRestOperation {
   public void execute(TracingContext tracingContext)
       throws AzureBlobFileSystemException {
 
+    // Since this might be a sub-sequential call triggered by a single
+    // file system call, a new tracing context should be used.
+    final TracingContext newTracingContext = createNewTracingContext(tracingContext);
+
     try {
       IOStatisticsBinding.trackDurationOfInvocation(abfsCounters,
           AbfsStatistic.getStatNameFromHttpCall(method),
-          () -> completeExecute(tracingContext));
+          () -> completeExecute(newTracingContext));
     } catch (AzureBlobFileSystemException aze) {
       throw aze;
     } catch (IOException e) {
@@ -409,6 +413,11 @@ public class AbfsRestOperation {
   @VisibleForTesting
   AbfsHttpOperation createHttpOperation() throws IOException {
     return new AbfsHttpOperation(url, method, requestHeaders);
+  }
+
+  @VisibleForTesting
+  final TracingContext createNewTracingContext(final TracingContext tracingContext) {
+    return new TracingContext(tracingContext);
   }
 
   /**

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAbfsRestOperationException.java
@@ -133,8 +133,8 @@ public class ITestAbfsRestOperationException extends AbstractAbfsIntegrationTest
       if (useBlobEndpoint) {
         Hashtable<String, String> metadata = new Hashtable<>();
         metadata.put("hi", "hello");
-        fs.getAbfsStore().setBlobMetadata(fs.makeQualified(nonExistedFilePath1), metadata, Mockito.mock(
-                TracingContext.class));
+        fs.getAbfsStore().setBlobMetadata(fs.makeQualified(nonExistedFilePath1),
+            metadata, getTestTracingContext(fs, true));
       }
     } catch (AbfsRestOperationException ex) {
       String errorMessage = ex.getLocalizedMessage();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAppend.java
@@ -254,8 +254,7 @@ public class ITestAzureBlobFileSystemAppend extends
     createAzCopyDirectory(new Path("/src"));
     createAzCopyFile(new Path("/src/file"));
     intercept(AbfsRestOperationException.class, () -> {
-      fs.getAbfsStore().getBlobProperty(new Path("/src"), Mockito.mock(
-              TracingContext.class));
+      fs.getAbfsStore().getBlobProperty(new Path("/src"), getTestTracingContext(fs, true));
     });
     intercept(FileNotFoundException.class, () -> fs.append(new Path("/src")));
   }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemAttributes.java
@@ -81,11 +81,11 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
 
     azcopyHelper.createFolderUsingAzcopy(fs.makeQualified(testPath).toUri().getPath().substring(1));
     // Assert that the folder is implicit
-    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs);
+    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true));
     testGetSetXAttrHelper(fs, testPath, testPath);
 
     // Assert that the folder is now explicit
-    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs);
+    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true));
   }
 
   /**
@@ -101,7 +101,7 @@ public class ITestAzureBlobFileSystemAttributes extends AbstractAbfsIntegrationT
     testGetSetXAttrHelper(fs, testPath, testPath);
 
     // Assert that the folder is now explicit
-    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs);
+    BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true));
   }
 
   private void testGetSetXAttrHelper(final AzureBlobFileSystem fs,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemBlobConfig.java
@@ -702,7 +702,7 @@ public class ITestAzureBlobFileSystemBlobConfig
       Boolean dfsEndpoint) throws Exception {
     AzureBlobFileSystem fs = getFileSystem();
     Assume.assumeFalse(
-        fs.getIsNamespaceEnabled(Mockito.mock(TracingContext.class)));
+        fs.getIsNamespaceEnabled(getTestTracingContext(fs, true)));
     Configuration configuration = Mockito.spy(getRawConfiguration());
     if(!FS_AZURE_ENABLE_BLOB_ENDPOINT.equalsIgnoreCase(configName)) {
       configuration.set(FS_AZURE_ENABLE_BLOB_ENDPOINT, Boolean.toString(DEFAULT_FS_AZURE_ENABLE_BLOBENDPOINT));

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemCreate.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
@@ -79,8 +78,6 @@ import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.TRUE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_ENABLE_BLOB_MKDIR_OVERWRITE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_LEASE_CREATE_NON_RECURSIVE;
 import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.FS_AZURE_MKDIRS_FALLBACK_TO_DFS;
-import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_DNS_PREFIX;
-import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.HttpHeaderConfigurations.X_MS_META_HDI_ISFOLDER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -140,7 +137,8 @@ public class ITestAzureBlobFileSystemCreate extends
     assertTrue(fs.exists(new Path("a/b/d")));
     // Asserting directory created still exists as explicit.
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/d"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/d"),
+            fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -155,7 +153,8 @@ public class ITestAzureBlobFileSystemCreate extends
     intercept(IOException.class, () -> fs.create(new Path("a/b/c")));
 
     // Asserting that directory still exists as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -206,7 +205,8 @@ public class ITestAzureBlobFileSystemCreate extends
     assertTrue(fs.exists(new Path("a/b/c/d")));
 
     // asserting that parent stays explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
   }
 
 
@@ -235,9 +235,11 @@ public class ITestAzureBlobFileSystemCreate extends
             fs.create(sourcePath, false));
 
     assertTrue("Parent directory should be explicit.",
-            BlobDirectoryStateHelper.isExplicitDirectory(sourcePath.getParent(), fs));
+            BlobDirectoryStateHelper.isExplicitDirectory(sourcePath.getParent(),
+                fs, getTestTracingContext(fs, true)));
     assertTrue("Path should be implicit.",
-            BlobDirectoryStateHelper.isImplicitDirectory(sourcePath, fs));
+            BlobDirectoryStateHelper.isImplicitDirectory(sourcePath,
+                fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -269,10 +271,12 @@ public class ITestAzureBlobFileSystemCreate extends
 
 
     assertTrue("Parent directory is implicit.",
-            BlobDirectoryStateHelper.isImplicitDirectory(parentPath, fs));
+            BlobDirectoryStateHelper.isImplicitDirectory(parentPath,
+                fs, getTestTracingContext(fs, true)));
 
     assertTrue("Path should also be implicit.",
-            BlobDirectoryStateHelper.isImplicitDirectory(sourcePath, fs));
+            BlobDirectoryStateHelper.isImplicitDirectory(sourcePath,
+                fs, getTestTracingContext(fs, true)));
 
   }
 
@@ -316,7 +320,8 @@ public class ITestAzureBlobFileSystemCreate extends
             eTagAfterCreateOverwrite.equals(eTagAfterCreate));
 
     assertTrue("Parent path should also change to explicit.",
-            BlobDirectoryStateHelper.isExplicitDirectory(parentPath, fs));
+            BlobDirectoryStateHelper.isExplicitDirectory(parentPath,
+                fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -372,11 +377,14 @@ public class ITestAzureBlobFileSystemCreate extends
     assertTrue(fs.exists(new Path("a/b/c/e")));
 
     //Asserting that directories created as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b"),
+        fs, getTestTracingContext(fs, true)));
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"),
+            fs, getTestTracingContext(fs, true)));
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/e"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/e"),
+            fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -391,7 +399,8 @@ public class ITestAzureBlobFileSystemCreate extends
     intercept(IOException.class, () -> fs.create(new Path("a/b")));
 
     //Asserting that directories created as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -410,10 +419,13 @@ public class ITestAzureBlobFileSystemCreate extends
     assertTrue(fs.exists(new Path("a/b/c/d/e")));
 
     //Asserting that directories created as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/"), fs));
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/"),
+        fs, getTestTracingContext(fs, true)));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d/e"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d/e"),
+            fs, getTestTracingContext(fs, true)));
   }
 
   /*
@@ -479,7 +491,8 @@ public class ITestAzureBlobFileSystemCreate extends
 
     assertTrue(fs.exists(new Path("a/b/c")));
     //Asserting that directories created as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -504,7 +517,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -517,7 +531,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.setWorkingDirectory(new Path("/"));
     fs.mkdirs(path);
 
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -530,7 +545,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -560,7 +576,8 @@ public class ITestAzureBlobFileSystemCreate extends
     CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
 
     // Assert that the directory created by mkdir exists as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
 
   }
 
@@ -578,7 +595,8 @@ public class ITestAzureBlobFileSystemCreate extends
     fs1.mkdirs(new Path("a/b/c"));
 
     //Asserting that directories created as explicit
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs1));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs1, getTestTracingContext(fs1, true)));
   }
 
   /**
@@ -618,10 +636,12 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that path created by azcopy becomes explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath,
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -651,10 +671,12 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that path created by azcopy becomes explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath,
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -684,10 +706,12 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(explicitPath, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(explicitPath,
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -718,10 +742,12 @@ public class ITestAzureBlobFileSystemCreate extends
     fs.mkdirs(path);
 
     // Asserting that path created by azcopy becomes explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath,
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(path,
+        fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -754,13 +780,14 @@ public class ITestAzureBlobFileSystemCreate extends
     });
 
     // Asserting that path created by azcopy becomes explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath, fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(implicitPath,
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the file still exists at path.
     assertFalse(
         fs.getAbfsStore().getBlobProperty(
             new Path(getFileSystem().makeQualified(path).toUri().getPath()),
-            Mockito.mock(TracingContext.class)
+            getTestTracingContext(fs, true)
         ).getIsDirectory()
     );
   }
@@ -832,11 +859,15 @@ public class ITestAzureBlobFileSystemCreate extends
 
     fs.mkdirs(new Path("a/b/c/d"));
 
-    assertTrue(BlobDirectoryStateHelper.isImplicitDirectory(new Path("a"), fs));
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b"), fs));
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isImplicitDirectory(new Path("a"),
+        fs, getTestTracingContext(fs, true)));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b"),
+        fs, getTestTracingContext(fs, true)));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"),
+            fs, getTestTracingContext(fs, true)));
   }
 
   /**
@@ -871,13 +902,17 @@ public class ITestAzureBlobFileSystemCreate extends
 
     fs.mkdirs(new Path("a/b/c/d"));
 
-    assertTrue(BlobDirectoryStateHelper.isImplicitDirectory(new Path("a/b"), fs));
+    assertTrue(BlobDirectoryStateHelper.isImplicitDirectory(new Path("a/b"),
+        fs, getTestTracingContext(fs, true)));
 
     // Asserting that the directory created by mkdir exists as explicit.
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a"), fs));
-    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"), fs));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a"),
+        fs, getTestTracingContext(fs, true)));
+    assertTrue(BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c"),
+        fs, getTestTracingContext(fs, true)));
     assertTrue(
-        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(new Path("a/b/c/d"),
+            fs, getTestTracingContext(fs, true)));
   }
 
   @Test

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelegationSASForBlobEndpoint.java
@@ -160,7 +160,7 @@ public class ITestAzureBlobFileSystemDelegationSASForBlobEndpoint
     }
     List<BlobProperty> blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), null, false);
+            getTestTracingContext(fs, true), null, false);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of files created in tests + the directory itself")
@@ -168,7 +168,7 @@ public class ITestAzureBlobFileSystemDelegationSASForBlobEndpoint
 
     blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), null, true);
+            getTestTracingContext(fs, true), null, true);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of files created in tests")

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -323,7 +323,7 @@ public class ITestAzureBlobFileSystemDelete extends
     fs.mkdirs(new Path("/testDir/dir1"));
     fs.create(new Path("/testDir/dir1/file1"));
     fs.getAbfsClient().deleteBlobPath(new Path("/testDir/dir1"),
-        null, Mockito.mock(TracingContext.class));
+        null, getTestTracingContext(fs, true));
 
     fs.delete(new Path("/testDir/dir1"), true);
 
@@ -354,7 +354,7 @@ public class ITestAzureBlobFileSystemDelete extends
             Mockito.nullable(String.class), Mockito.nullable(Integer.class),
             Mockito.any(TracingContext.class));
     fs.getAbfsClient().deleteBlobPath(new Path("/testDir/dir1"),
-        null, Mockito.mock(TracingContext.class));
+        null, getTestTracingContext(fs, true));
 
     fs.delete(new Path("/testDir/dir1"), true);
 
@@ -368,7 +368,7 @@ public class ITestAzureBlobFileSystemDelete extends
     fs.mkdirs(new Path("/testDir/dir1"));
     fs.create(new Path("/testDir/dir1/file1"));
     fs.getAbfsClient().deleteBlobPath(new Path("/testDir/"),
-        null, Mockito.mock(TracingContext.class));
+        null, getTestTracingContext(fs, true));
 
     fs.delete(new Path("/testDir/dir1"), true);
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemDelete.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil;
 import org.apache.hadoop.fs.azurebfs.services.AbfsHttpOperation;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
@@ -580,5 +581,27 @@ public class ITestAzureBlobFileSystemDelete extends
         .getListBlobs(Mockito.nullable(String.class),
             Mockito.nullable(String.class), Mockito.nullable(String.class),
             Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
+  }
+
+  @Test
+  public void deleteBlobDirParallelThreadToDeleteOnDifferentTracingContext()
+      throws Exception {
+    Assume.assumeTrue(getPrefixMode(getFileSystem()) == PrefixMode.BLOB);
+    Configuration configuration = getRawConfiguration();
+    AzureBlobFileSystem fs = Mockito.spy(
+        (AzureBlobFileSystem) FileSystem.newInstance(configuration));
+    AzureBlobFileSystemStore spiedStore = Mockito.spy(fs.getAbfsStore());
+    AbfsClient spiedClient = Mockito.spy(fs.getAbfsClient());
+
+    Mockito.doReturn(spiedStore).when(fs).getAbfsStore();
+    spiedStore.setClient(spiedClient);
+
+    fs.mkdirs(new Path("/testDir"));
+    fs.create(new Path("/testDir/file1"));
+    fs.create(new Path("/testDir/file2"));
+
+    AbfsClientTestUtil.hookOnRestOpsForTracingContextSingularity(spiedClient);
+
+    fs.delete(new Path("/testDir"), true);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemExplictImplicitRename.java
@@ -55,20 +55,19 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     createAzCopyDirectory(new Path("/src"));
     createAzCopyFile(new Path("/src/file"));
     intercept(AbfsRestOperationException.class, () -> {
-      fs.getAbfsStore().getBlobProperty(new Path("/src"), Mockito.mock(
-          TracingContext.class));
+      fs.getAbfsStore().getBlobProperty(new Path("/src"), getTestTracingContext(fs, true));
     });
     Assert.assertNotNull(fs.getAbfsStore()
         .getBlobProperty(new Path("/src/file"),
-            Mockito.mock(TracingContext.class)));
+            getTestTracingContext(fs, true)));
     Assert.assertTrue(fs.rename(new Path("/src/file"), new Path("/dstFile")));
     Assert.assertNotNull(fs.getAbfsStore()
         .getBlobProperty(new Path("/dstFile"),
-            Mockito.mock(TracingContext.class)));
+            getTestTracingContext(fs, true)));
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/src/file"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
 
     Assert.assertFalse(fs.rename(new Path("/src/file"), new Path("/dstFile2")));
@@ -79,8 +78,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     AzureBlobFileSystem fs = getFileSystem();
     createAzCopyDirectory(new Path("/src"));
     intercept(AbfsRestOperationException.class, () -> {
-      fs.getAbfsStore().getBlobProperty(new Path("/src"), Mockito.mock(
-          TracingContext.class));
+      fs.getAbfsStore().getBlobProperty(new Path("/src"), getTestTracingContext(fs, true));
     });
 
     Assert.assertFalse(fs.rename(new Path("/src/file"), new Path("/dstFile2")));
@@ -96,7 +94,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/dstDir"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
     Assert.assertTrue(fs.rename(new Path("/file"), new Path("/dstDir")));
     Assert.assertTrue(fs.exists(new Path("/dstDir/file")));
@@ -113,14 +111,14 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/dst"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
     Assert.assertTrue(fs.rename(new Path("/file"), new Path("/dst/dir")));
     Assert.assertTrue(fs.exists(new Path("/dst/dir/file")));
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/file"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
   }
 
@@ -135,14 +133,14 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/dst/dir"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
     Assert.assertTrue(fs.rename(new Path("/file"), new Path("/dst/dir")));
     Assert.assertTrue(fs.exists(new Path("/dst/dir/file")));
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/file"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
   }
 
@@ -157,19 +155,19 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/dst"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/dst/dir"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
     Assert.assertTrue(fs.rename(new Path("/file"), new Path("/dst/dir")));
     Assert.assertTrue(fs.exists(new Path("/dst/dir/file")));
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore()
           .getBlobProperty(new Path("/file"),
-              Mockito.mock(TracingContext.class));
+              getTestTracingContext(fs, true));
     });
   }
 
@@ -768,7 +766,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     if (dstParentExists && !isDstParentFile && !dstParentExplicit) {
       intercept(AbfsRestOperationException.class, () -> {
         fs.getAbfsStore()
-            .getBlobProperty(dstParent, Mockito.mock(TracingContext.class));
+            .getBlobProperty(dstParent, getTestTracingContext(fs, true));
       });
     }
 
@@ -807,7 +805,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
     if (dstParentExists && !isDstParentFile && !dstParentExplicit && !dstExplicit) {
       intercept(AbfsRestOperationException.class, () -> {
         fs.getAbfsStore()
-            .getBlobProperty(dstParent, Mockito.mock(TracingContext.class));
+            .getBlobProperty(dstParent, getTestTracingContext(fs, true));
       });
     }
 
@@ -849,19 +847,19 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
       createAzCopyFile(new Path(srcSubDir, "subFile"));
       intercept(AbfsRestOperationException.class, () -> {
         fs.getAbfsStore()
-            .getBlobProperty(srcSubDir, Mockito.mock(TracingContext.class));
+            .getBlobProperty(srcSubDir, getTestTracingContext(fs, true));
       });
     }
     if (!srcParentExplicit) {
       intercept(AbfsRestOperationException.class, () -> {
         fs.getAbfsStore()
-            .getBlobProperty(srcParent, Mockito.mock(TracingContext.class));
+            .getBlobProperty(srcParent, getTestTracingContext(fs, true));
       });
     }
     if (!srcExplicit) {
       intercept(AbfsRestOperationException.class, () -> {
         fs.getAbfsStore()
-            .getBlobProperty(src, Mockito.mock(TracingContext.class));
+            .getBlobProperty(src, getTestTracingContext(fs, true));
       });
     }
   }
@@ -870,7 +868,7 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
       throws AzureBlobFileSystemException {
     try {
       fs.getAbfsClient()
-          .deleteBlobPath(srcParent, null, Mockito.mock(TracingContext.class));
+          .deleteBlobPath(srcParent, null, getTestTracingContext(fs, true));
     } catch (AbfsRestOperationException ex) {
       if(ex.getStatusCode() != HttpURLConnection.HTTP_NOT_FOUND) {
         throw ex;
@@ -942,22 +940,22 @@ public class ITestAzureBlobFileSystemExplictImplicitRename
       if (dstExist) {
         Assert.assertTrue(fs.getAbfsStore()
             .getBlobProperty(new Path(dst, src.getName()),
-                Mockito.mock(TracingContext.class))
+                getTestTracingContext(fs, true))
             .getIsDirectory());
       } else {
         Assert.assertTrue(fs.getAbfsStore()
-            .getBlobProperty(dst, Mockito.mock(TracingContext.class))
+            .getBlobProperty(dst, getTestTracingContext(fs, true))
             .getIsDirectory());
       }
     } else {
       Assert.assertFalse(fs.rename(src, dst));
       Assert.assertTrue(fs.getAbfsStore()
-          .getListBlobs(src, null, null, Mockito.mock(TracingContext.class), null,
+          .getListBlobs(src, null, null, getTestTracingContext(fs, true), null,
               false)
           .size() > 0);
       if (dstExist) {
         Assert.assertTrue(fs.getAbfsStore()
-            .getListBlobs(dst, null, null, Mockito.mock(TracingContext.class), null,
+            .getListBlobs(dst, null, null, getTestTracingContext(fs, true), null,
                 false)
             .size() > 0);
       }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemFileStatus.java
@@ -170,7 +170,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
     azcopyHelper.createFileUsingAzcopy(fs.makeQualified(testPath).toUri().getPath().substring(1));
 
     assertTrue("Parent directory is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     // Assert getFileStatus Succeed on path
     FileStatus fileStatus = fs.getFileStatus(testPath);
@@ -186,7 +186,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
     fs.create(testPath);
 
     assertTrue("Parent directory is explicit.",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     FileStatus fileStatus = fs.getFileStatus(testPath);
     assertNotNull(fileStatus.getPath());
@@ -207,9 +207,9 @@ public class ITestAzureBlobFileSystemFileStatus extends
     azcopyHelper.createFolderUsingAzcopy(fs.makeQualified(testPath).toUri().getPath().substring(1));
 
     assertTrue("Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
     assertTrue("Parent directory is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     // Assert that getFileStatus succeeds
     FileStatus fileStatus = fs.getFileStatus(testPath);
@@ -233,9 +233,9 @@ public class ITestAzureBlobFileSystemFileStatus extends
     fs.mkdirs(testPath.getParent());
 
     assertTrue("Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
     assertTrue("Parent directory is explicit.",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     // Assert that getFileStatus succeeds
     FileStatus fileStatus = fs.getFileStatus(testPath);
@@ -251,9 +251,9 @@ public class ITestAzureBlobFileSystemFileStatus extends
     fs.mkdirs(testPath);
 
     assertTrue("Parent directory is explicit.",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
     assertTrue("Path is explicit.",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
 
     // Assert that getFileStatus Succeeds
     FileStatus fileStatus = fs.getFileStatus(testPath);
@@ -269,7 +269,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
     fs.mkdirs(testPath.getParent());
 
     assertTrue("Parent directory is explicit.",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     // assert that getFileStatus fails
     intercept(IOException.class,
@@ -291,7 +291,7 @@ public class ITestAzureBlobFileSystemFileStatus extends
         testPath.getParent()).toUri().getPath().substring(1));
 
     assertTrue("Parent directory is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath.getParent(), fs, getTestTracingContext(fs, true)));
 
     // assert that getFileStatus Fails with IOException
     intercept(IOException.class,

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemListStatus.java
@@ -167,9 +167,9 @@ public class ITestAzureBlobFileSystemListStatus extends
     List<FileStatus> fileStatuses = new ArrayList<>();
     spiedStore.listStatus(new Path("/"), "", fileStatuses, true, null, spiedTracingContext);
 
-    // Assert that there were 2 paginated ListBlob calls made and 2 new tracing context were created.
+    // Assert that there were 2 paginated ListBlob calls made and new tracing context were created.
     Mockito.verify(spiedClient, times(2)).getListBlobs(any(), any(), any(), any(), any());
-    AbfsRestOperationTestUtil.assertTracingContextInstantiationCount(spiedClient, 2);
+    Mockito.verify(spiedTracingContext, times(0)).constructHeader(any(), any());
   }
 
   /**
@@ -344,7 +344,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     Path dir1 = new Path("a");
     azcopyHelper.createFolderUsingAzcopy(fs.makeQualified(dir1).toUri().getPath().substring(1));
     assertTrue("Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(dir1, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(dir1, fs, getTestTracingContext(fs, true)));
 
     // Assert that implicit directory is returned
     FileStatus[] fileStatuses = fs.listStatus(root);
@@ -373,7 +373,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     Path dir2 = new Path("c");
     azcopyHelper.createFolderUsingAzcopy(fs.makeQualified(dir2).toUri().getPath().substring(1));
     assertTrue("Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(dir2, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(dir2, fs, getTestTracingContext(fs, true)));
 
     // Assert that three entries are returned in alphabetic order.
     fileStatuses = fs.listStatus(root);
@@ -408,7 +408,7 @@ public class ITestAzureBlobFileSystemListStatus extends
     azcopyHelper.createFolderUsingAzcopy(
         fs.makeQualified(testPath).toUri().getPath().substring(1));
     assertTrue("Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
 
     // Assert that one entry is returned as implicit child.
     FileStatus[] fileStatuses = fs.listStatus(testPath);
@@ -437,11 +437,11 @@ public class ITestAzureBlobFileSystemListStatus extends
         fs.makeQualified(implicitChild).toUri().getPath().substring(1));
 
     assertTrue("Test path is explicit",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
     assertTrue("explicitChild Path is explicit",
-        BlobDirectoryStateHelper.isExplicitDirectory(explicitChild, fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(explicitChild, fs, getTestTracingContext(fs, true)));
     assertTrue("implicitChild Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(implicitChild, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(implicitChild, fs, getTestTracingContext(fs, true)));
 
     // Assert that three entry is returned.
     FileStatus[] fileStatuses = fs.listStatus(testPath);
@@ -474,11 +474,11 @@ public class ITestAzureBlobFileSystemListStatus extends
     fs.mkdirs(explicitChild);
 
     assertTrue("Test path is explicit",
-        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(testPath, fs, getTestTracingContext(fs, true)));
     assertTrue("explicitChild Path is explicit",
-        BlobDirectoryStateHelper.isExplicitDirectory(explicitChild, fs));
+        BlobDirectoryStateHelper.isExplicitDirectory(explicitChild, fs, getTestTracingContext(fs, true)));
     assertTrue("implicitChild2 Path is implicit.",
-        BlobDirectoryStateHelper.isImplicitDirectory(implicitChild2, fs));
+        BlobDirectoryStateHelper.isImplicitDirectory(implicitChild2, fs, getTestTracingContext(fs, true)));
 
     // Assert that only 2 entry is returned.
     FileStatus[] fileStatuses = fs.listStatus(testPath);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemMkDir.java
@@ -173,8 +173,7 @@ public class ITestAzureBlobFileSystemMkDir extends AbstractAbfsIntegrationTest {
 
     createAzCopyDirectory(new Path("/src"));
     intercept(AbfsRestOperationException.class, () -> {
-      store.getBlobProperty(new Path("/src"), Mockito.mock(
-              TracingContext.class));
+      store.getBlobProperty(new Path("/src"), getTestTracingContext(fs, true));
     });
     fs.mkdirs(new Path("/src/dir"));
     Mockito.verify(testClient, Mockito.times(0)).getPathStatus(Mockito.any(String.class),

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestAzureBlobFileSystemRename.java
@@ -263,7 +263,7 @@ public class ITestAzureBlobFileSystemRename extends
     assumeNonHnsAccountBlobEndpoint(fs);
     fs.create(new Path("/srcDir/dir/file"));
     fs.getAbfsStore().getClient().deleteBlobPath(new Path("/srcDir/dir"), null,
-        Mockito.mock(TracingContext.class));
+        getTestTracingContext(fs, true));
     Assert.assertTrue(fs.rename(new Path("/srcDir/dir"), new Path("/srcDir")));
   }
 
@@ -493,7 +493,7 @@ public class ITestAzureBlobFileSystemRename extends
       try {
         fs.getAbfsClient()
             .releaseBlobLease(entry.getKey(), entry.getValue(),
-                Mockito.mock(TracingContext.class));
+                getTestTracingContext(fs, true));
       } catch (AbfsRestOperationException ex) {
 
       }
@@ -637,7 +637,7 @@ public class ITestAzureBlobFileSystemRename extends
       try {
         fs.getAbfsClient()
             .releaseBlobLease(entry.getKey(), entry.getValue(),
-                Mockito.mock(TracingContext.class));
+                getTestTracingContext(fs, true));
       } catch (AbfsRestOperationException ex) {
 
       }
@@ -783,7 +783,7 @@ public class ITestAzureBlobFileSystemRename extends
      */
     for(Map.Entry<String, String> entry : pathLeaseIdMap.entrySet()) {
       try {
-        fs.getAbfsClient().releaseBlobLease(entry.getKey(), entry.getValue(), Mockito.mock(TracingContext.class));
+        fs.getAbfsClient().releaseBlobLease(entry.getKey(), entry.getValue(), getTestTracingContext(fs, true));
       } catch (AbfsRestOperationException ex) {
 
       }
@@ -1065,7 +1065,7 @@ public class ITestAzureBlobFileSystemRename extends
       try {
         fs.getAbfsClient()
             .releaseBlobLease(entry.getKey(), entry.getValue(),
-                Mockito.mock(TracingContext.class));
+                getTestTracingContext(fs, true));
       } catch (Exception e) {}
     }
 
@@ -1438,7 +1438,7 @@ public class ITestAzureBlobFileSystemRename extends
 
     fs.getAbfsClient()
         .deleteBlobPath(new Path("/test1/test2"),
-            null, Mockito.mock(TracingContext.class));
+            null, getTestTracingContext(fs, true));
     fs.mkdirs(new Path("/test4/test5"));
     fs.rename(new Path("/test4"), new Path("/test1/test2"));
 
@@ -1450,7 +1450,7 @@ public class ITestAzureBlobFileSystemRename extends
 
     fs.getAbfsClient()
         .deleteBlobPath(new Path("/test1/test2/test4/test5/test6"),
-            null, Mockito.mock(TracingContext.class));
+            null, getTestTracingContext(fs, true));
     fs.mkdirs(new Path("/test7"));
     fs.create(new Path("/test7/file"));
     fs.rename(new Path("/test7"), new Path("/test1/test2/test4/test5/test6"));
@@ -1465,16 +1465,16 @@ public class ITestAzureBlobFileSystemRename extends
     fs.create(new Path("/test1/test2/file1"));
     fs.getAbfsStore()
         .getClient()
-        .deleteBlobPath(new Path("/test1"), null, Mockito.mock(TracingContext.class));
+        .deleteBlobPath(new Path("/test1"), null, getTestTracingContext(fs, true));
     intercept(AbfsRestOperationException.class, () -> {
       fs.getAbfsStore().getBlobProperty(new Path("/test1"),
-              Mockito.mock(TracingContext.class));
+          getTestTracingContext(fs, true));
     });
     fs.mkdirs(new Path("/test2"));
     fs.rename(new Path("/test1"), new Path("/test2"));
     Assert.assertTrue(fs.getAbfsStore()
         .getBlobProperty(new Path("/test2/test1"),
-            Mockito.mock(TracingContext.class)).getIsDirectory());
+            getTestTracingContext(fs, true)).getIsDirectory());
   }
 
   @Test
@@ -1647,7 +1647,7 @@ public class ITestAzureBlobFileSystemRename extends
       final AtomicInteger threadsCompleted) {
     try {
       fs.getAbfsClient().copyBlob(new Path("/src"),
-          new Path("/dst"), null, Mockito.mock(TracingContext.class));
+          new Path("/dst"), null, getTestTracingContext(fs, true));
     } catch (AbfsRestOperationException ex) {
       if (ex.getStatusCode() == HttpURLConnection.HTTP_CONFLICT) {
         dstBlobAlreadyThereExceptionReceived[0] = true;
@@ -1665,12 +1665,12 @@ public class ITestAzureBlobFileSystemRename extends
     fs.create(new Path("/src"));
     fs.getAbfsStore()
         .getClient()
-        .deleteBlobPath(new Path("/src"), null, Mockito.mock(TracingContext.class));
+        .deleteBlobPath(new Path("/src"), null, getTestTracingContext(fs, true));
     Boolean srcBlobNotFoundExReceived = false;
     try {
       fs.getAbfsStore()
           .copyBlob(new Path("/src"), new Path("/dst"),
-              null, Mockito.mock(TracingContext.class));
+              null, getTestTracingContext(fs, true));
     } catch (AbfsRestOperationException ex) {
       if (ex.getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND) {
         srcBlobNotFoundExReceived = true;
@@ -1795,7 +1795,7 @@ public class ITestAzureBlobFileSystemRename extends
 
     fs.getAbfsClient()
         .acquireBlobLease("/hbase/testDir/file2", -1,
-            Mockito.mock(TracingContext.class));
+            getTestTracingContext(fs, true));
 
     AbfsLease[] leases = new AbfsLease[1];
     Mockito.doAnswer(answer -> {
@@ -2134,11 +2134,11 @@ public class ITestAzureBlobFileSystemRename extends
 
     if (srcMarkerToBeDeleted) {
       client.deleteBlobPath(new Path("/hbase/testDir"), null,
-          Mockito.mock(TracingContext.class));
+          getTestTracingContext(fs, true));
     }
 
     AbfsRestOperation op = client.acquireBlobLease("/hbase/testDir/file5", -1,
-        Mockito.mock(TracingContext.class));
+        getTestTracingContext(fs, true));
     String leaseId = op.getResult()
         .getResponseHeader(HttpHeaderConfigurations.X_MS_LEASE_ID);
 
@@ -2166,13 +2166,13 @@ public class ITestAzureBlobFileSystemRename extends
     for (Map.Entry<String, String> entry : pathLeaseIdMap.entrySet()) {
       try {
         client.releaseBlobLease(entry.getKey(), entry.getValue(),
-            Mockito.mock(TracingContext.class));
+            getTestTracingContext(fs, true));
       } catch (Exception e) {
 
       }
     }
     client.releaseBlobLease("/hbase/testDir/file5", leaseId,
-        Mockito.mock(TracingContext.class));
+        getTestTracingContext(fs, true));
     leaseCanBeTaken.set(true);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestFileSystemInitialization.java
@@ -22,7 +22,6 @@ import java.net.URI;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -32,7 +31,6 @@ import org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.services.AuthType;
 import org.apache.hadoop.fs.azurebfs.services.PrefixMode;
-import org.apache.hadoop.fs.azurebfs.utils.TracingContext;
 
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_AVAILABLE;
 import static org.apache.hadoop.fs.CommonPathCapabilities.ETAGS_PRESERVED_IN_RENAME;
@@ -41,7 +39,6 @@ import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.ABFS_
 import static org.apache.hadoop.fs.azurebfs.constants.FileSystemUriSchemes.WASB_DNS_PREFIX;
 import static org.apache.hadoop.fs.azurebfs.constants.InternalConstants.CAPABILITY_SAFE_READAHEAD;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * Test AzureBlobFileSystem initialization.
@@ -125,11 +122,11 @@ public class ITestFileSystemInitialization extends AbstractAbfsIntegrationTest {
     final AzureBlobFileSystem fs = getFileSystem();
     // assert that createContainer fails for already existing fileSystem.
     intercept(AbfsRestOperationException.class,
-        () -> fs.getAbfsStore().createFilesystem(Mockito.mock(TracingContext.class),
+        () -> fs.getAbfsStore().createFilesystem(getTestTracingContext(fs, true),
         fs.getAbfsStore().getPrefixMode() == PrefixMode.BLOB));
 
-    fs.getAbfsStore().deleteFilesystem(Mockito.mock(TracingContext.class));
+    fs.getAbfsStore().deleteFilesystem(getTestTracingContext(fs, true));
     intercept(AbfsRestOperationException.class,
-        () -> fs.getAbfsStore().getFilesystemProperties(Mockito.mock(TracingContext.class)));
+        () -> fs.getAbfsStore().getFilesystemProperties(getTestTracingContext(fs, true)));
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlob.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlob.java
@@ -53,7 +53,7 @@ public class ITestListBlob extends
      */
     blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), null, false);
+            getTestTracingContext(fs, true), null, false);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of files created in tests + the directory itself")
@@ -65,7 +65,7 @@ public class ITestListBlob extends
      */
     blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), null, true);
+            getTestTracingContext(fs, true), null, true);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of files created in tests")
@@ -78,7 +78,7 @@ public class ITestListBlob extends
      */
     blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), 13, false);
+            getTestTracingContext(fs, true), 13, false);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of files created in tests + the directory itself")
@@ -91,7 +91,7 @@ public class ITestListBlob extends
      */
     blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), 5, false);
+            getTestTracingContext(fs, true), 5, false);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of maxResult given")
@@ -128,7 +128,7 @@ public class ITestListBlob extends
 
     List<BlobProperty> blobProperties = fs.getAbfsStore()
         .getListBlobs(new Path("dir"), null, null,
-            Mockito.mock(TracingContext.class), 5, false);
+            getTestTracingContext(fs, true), 5, false);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should match the number of maxResult given")
@@ -158,7 +158,7 @@ public class ITestListBlob extends
     // There will be no BlobPrefix element and only explicit blobs will be returned
     blobProperties = fs.getAbfsStore()
         .getListBlobs(level0.getParent(), null, null,
-            Mockito.mock(TracingContext.class), null, true);
+            getTestTracingContext(fs, true), null, true);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should return all blobs in hierarchy")
@@ -168,7 +168,7 @@ public class ITestListBlob extends
     // There will be repetition of marker blobs.
     blobProperties = fs.getAbfsStore()
         .getListBlobs(level0.getParent(), null, "/",
-            Mockito.mock(TracingContext.class), null, true);
+            getTestTracingContext(fs, true), null, true);
     Assertions.assertThat(blobProperties)
         .describedAs(
             "BlobList should return only immediate Children")

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -36,9 +36,11 @@ import org.mockito.Mockito;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.azurebfs.constants.FSOperationType;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AbfsRestOperationException;
 import org.apache.hadoop.fs.azurebfs.contracts.exceptions.AzureBlobFileSystemException;
 import org.apache.hadoop.fs.azurebfs.services.AbfsClient;
+import org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil;
 import org.apache.hadoop.fs.azurebfs.services.AbfsRestOperation;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobConsumer;
 import org.apache.hadoop.fs.azurebfs.services.ListBlobProducer;
@@ -68,7 +70,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
     configuration.set(FS_AZURE_PRODUCER_QUEUE_MAX_SIZE, "10");
     AzureBlobFileSystem fs = (AzureBlobFileSystem) FileSystem.newInstance(
         configuration);
-    AbfsClient client = fs.getAbfsClient();
+    AbfsClient client = Mockito.spy(fs.getAbfsClient());
     AbfsClient spiedClient = Mockito.spy(client);
     fs.getAbfsStore().setClient(spiedClient);
     fs.setWorkingDirectory(new Path("/"));
@@ -113,10 +115,13 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
             Mockito.nullable(Integer.class),
             Mockito.nullable(TracingContext.class));
 
-
+    AbfsClientTestUtil.hookOnRestOpsForTracingContextSingularity(client);
+    TracingContext tracingContext = new TracingContext("clientCorrelationId",
+        "fileSystemId", FSOperationType.TEST_OP,
+        getConfiguration().getTracingHeaderFormat(),
+        null);
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
-        null, Mockito.mock(
-        TracingContext.class));
+        null, tracingContext);
     ListBlobConsumer consumer = new ListBlobConsumer(queue);
     latch.await();
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/ITestListBlobProducer.java
@@ -115,8 +115,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
 
 
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
-        null, Mockito.mock(
-        TracingContext.class));
+        null, getTestTracingContext(fs, true));
     ListBlobConsumer consumer = new ListBlobConsumer(queue);
     latch.await();
 
@@ -162,8 +161,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
     ListBlobQueue queue = new ListBlobQueue(getConfiguration().getProducerQueueMaxSize(),
         getConfiguration().getProducerQueueMaxSize());
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
-        null, Mockito.mock(
-        TracingContext.class));
+        null, getTestTracingContext(fs, true));
     ListBlobConsumer consumer = new ListBlobConsumer(queue);
 
     Boolean exceptionCaught = false;
@@ -227,8 +225,7 @@ public class ITestListBlobProducer extends AbstractAbfsIntegrationTest {
             Mockito.nullable(Integer.class), Mockito.any(TracingContext.class));
 
     ListBlobProducer producer = new ListBlobProducer("src/", spiedClient, queue,
-        null, Mockito.mock(
-        TracingContext.class));
+        null, getTestTracingContext(fs, true));
 
     producer.waitForProcessCompletion();
     Mockito.verify(spiedClient, Mockito.times(1))

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientTestUtil.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientTestUtil.java
@@ -20,14 +20,11 @@ package org.apache.hadoop.fs.azurebfs.services;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.ArrayList;
 
 import org.mockito.Mockito;
-import org.mockito.stubbing.Stubber;
 
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.functional.BiFunctionRaisingIOE;
 import org.apache.hadoop.util.functional.FunctionRaisingIOE;
 
@@ -35,10 +32,8 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_GET;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
 import static org.apache.hadoop.fs.azurebfs.services.AuthType.OAuth;
-import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_JDK_MESSAGE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.when;
 
 public final class AbfsClientTestUtil {
 
@@ -87,8 +82,8 @@ public final class AbfsClientTestUtil {
     Mockito.doReturn(abfsRestOperation).when(spiedClient).getListBlobOperation(any(), any());
 
     addMockBehaviourToAbfsClient(spiedClient, retryPolicy);
-
     addMockBehaviourToRestOpAndHttpOp(abfsRestOperation, httpOperation);
+
     functionRaisingIOE.apply(httpOperation);
   }
 

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientTestUtil.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsClientTestUtil.java
@@ -18,14 +18,30 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.util.ArrayList;
 
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Stubber;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.functional.BiFunctionRaisingIOE;
 import org.apache.hadoop.util.functional.FunctionRaisingIOE;
 
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_GET;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
+import static org.apache.hadoop.fs.azurebfs.services.AuthType.OAuth;
+import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_JDK_MESSAGE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
 
 public final class AbfsClientTestUtil {
 
@@ -55,5 +71,73 @@ public final class AbfsClientTestUtil {
         })
         .when(spiedClient)
         .getCopyBlobOperation(Mockito.any(URL.class), Mockito.anyList());
+  }
+
+  public static void setMockAbfsRestOperationForListBlobOperation(
+      final AbfsClient spiedClient) throws Exception {
+    ExponentialRetryPolicy retryPolicy = Mockito.mock(ExponentialRetryPolicy.class);
+    AbfsHttpOperation httpOperation = Mockito.mock(AbfsHttpOperation.class);
+    AbfsRestOperation abfsRestOperation = Mockito.spy(new AbfsRestOperation(
+        AbfsRestOperationType.GetListBlobProperties,
+        spiedClient,
+        HTTP_METHOD_GET,
+        null,
+        new ArrayList<>()
+    ));
+
+    Mockito.doReturn(abfsRestOperation).when(spiedClient).getListBlobOperation(any(), any());
+
+    addMockBehaviourToAbfsClient(spiedClient, retryPolicy);
+    Mockito.doReturn(false).when(retryPolicy).shouldRetry(0, HTTP_OK);
+
+    addMockBehaviourToRestOpAndHttpOp(abfsRestOperation, httpOperation);
+    BlobProperty blob = new BlobProperty();
+    blob.setPath(new Path("/abc.txt"));
+    blob.setName("abc.txt");
+    BlobList blobListWithNextMarker = new BlobList();
+    blobListWithNextMarker.addBlobProperty(blob);
+    blobListWithNextMarker.setNextMarker("nextMarker");
+    BlobList blobListWithoutNextMarker = new BlobList();
+    blobListWithoutNextMarker.addBlobProperty(blob);
+    blobListWithoutNextMarker.setNextMarker("");
+    when(httpOperation.getBlobList()).thenReturn(blobListWithNextMarker)
+        .thenReturn(blobListWithoutNextMarker);
+
+    Stubber stubber = Mockito.doThrow(
+        new SocketTimeoutException(CONNECTION_TIMEOUT_JDK_MESSAGE));
+    stubber.doNothing().when(httpOperation).processResponse(
+        nullable(byte[].class), nullable(int.class), nullable(int.class));
+
+    when(httpOperation.getStatusCode()).thenReturn(-1).thenReturn(HTTP_OK);
+  }
+
+  public static void addMockBehaviourToRestOpAndHttpOp(final AbfsRestOperation abfsRestOperation,
+      final AbfsHttpOperation httpOperation) throws IOException {
+    HttpURLConnection httpURLConnection = Mockito.mock(HttpURLConnection.class);
+    Mockito.doNothing().when(httpURLConnection)
+        .setRequestProperty(nullable(String.class), nullable(String.class));
+    Mockito.doReturn(httpURLConnection).when(httpOperation).getConnection();
+    Mockito.doReturn("").when(abfsRestOperation).getClientLatency();
+    Mockito.doReturn(httpOperation).when(abfsRestOperation).createHttpOperation();
+  }
+
+  public static void addMockBehaviourToAbfsClient(final AbfsClient abfsClient,
+      final ExponentialRetryPolicy retryPolicy) throws IOException {
+    Mockito.doReturn(OAuth).when(abfsClient).getAuthType();
+    Mockito.doReturn("").when(abfsClient).getAccessToken();
+    AbfsThrottlingIntercept intercept = Mockito.mock(
+        AbfsThrottlingIntercept.class);
+    Mockito.doReturn(intercept).when(abfsClient).getIntercept();
+    Mockito.doNothing()
+        .when(intercept)
+        .sendingRequest(any(), nullable(AbfsCounters.class));
+    Mockito.doNothing().when(intercept).updateMetrics(any(), any());
+
+    Mockito.doReturn(retryPolicy).when(abfsClient).getRetryPolicy();
+    Mockito.doReturn(true)
+        .when(retryPolicy)
+        .shouldRetry(nullable(Integer.class), nullable(Integer.class));
+    Mockito.doReturn(false).when(retryPolicy).shouldRetry(1, HTTP_OK);
+    Mockito.doReturn(false).when(retryPolicy).shouldRetry(2, HTTP_OK);
   }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationTestUtil.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationTestUtil.java
@@ -47,4 +47,5 @@ public final class AbfsRestOperationTestUtil {
   public static void setResult(final AbfsRestOperation op, final AbfsHttpOperation result) {
     op.setResult(result);
   }
+
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationTestUtil.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/AbfsRestOperationTestUtil.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import org.mockito.Mockito;
 
 import org.apache.hadoop.util.functional.BiFunctionRaisingIOE;
-import org.apache.hadoop.util.functional.FunctionRaisingIOE;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 
 public final class AbfsRestOperationTestUtil {
 
@@ -48,4 +50,8 @@ public final class AbfsRestOperationTestUtil {
     op.setResult(result);
   }
 
+  public static void assertTracingContextInstantiationCount(final AbfsClient client, final int numberOfInstantiation) {
+    AbfsRestOperation op = client.getListBlobOperation(any(), any());
+    Mockito.verify(op, times(numberOfInstantiation)).createNewTracingContext(any());
+  }
 }

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -336,7 +336,8 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     when(client.createRequestUrl(any(), any())).thenCallRealMethod();
     when(client.getAccessToken()).thenCallRealMethod();
     when(client.getAbfsRestOperation(
-        Mockito.any(AbfsRestOperationType.class), Mockito.anyString(), Mockito.any(URL.class),
+        Mockito.any(AbfsRestOperationType.class), Mockito.anyString(),
+        Mockito.any(URL.class),
         Mockito.anyList())).thenCallRealMethod();
     when(client.getSharedKeyCredentials()).thenCallRealMethod();
     when(client.createDefaultHeaders()).thenCallRealMethod();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsClient.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.security.ssl.DelegatingSSLSocketFactory;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.APPEND_ACTION;
+import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_DELETE;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PATCH;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HTTP_METHOD_PUT;
 import static org.apache.hadoop.fs.azurebfs.constants.AbfsHttpConstants.HUNDRED_CONTINUE;
@@ -334,6 +335,9 @@ public final class ITestAbfsClient extends AbstractAbfsIntegrationTest {
     when(client.createDefaultUriQueryBuilder()).thenCallRealMethod();
     when(client.createRequestUrl(any(), any())).thenCallRealMethod();
     when(client.getAccessToken()).thenCallRealMethod();
+    when(client.getAbfsRestOperation(
+        Mockito.any(AbfsRestOperationType.class), Mockito.anyString(), Mockito.any(URL.class),
+        Mockito.anyList())).thenCallRealMethod();
     when(client.getSharedKeyCredentials()).thenCallRealMethod();
     when(client.createDefaultHeaders()).thenCallRealMethod();
     when(client.getAbfsConfiguration()).thenReturn(abfsConfig);

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/ITestAbfsRestOperation.java
@@ -290,6 +290,7 @@ public class ITestAbfsRestOperation extends AbstractAbfsIntegrationTest {
     TracingContext tracingContext = Mockito.spy(new TracingContext("abcd",
         "abcde", FSOperationType.APPEND,
         TracingHeaderFormat.ALL_ID_FORMAT, null));
+    Mockito.doReturn(tracingContext).when(op).createNewTracingContext(Mockito.any());
 
     switch (errorType) {
     case WRITE:

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
@@ -201,6 +201,7 @@ public class TestAbfsRestOperationMockFailures {
 
     TracingContext tracingContext = Mockito.mock(TracingContext.class);
     Mockito.doNothing().when(tracingContext).setRetryCount(nullable(int.class));
+    Mockito.doReturn(tracingContext).when(abfsRestOperation).createNewTracingContext(any());
 
     int[] count = new int[1];
     count[0] = 0;
@@ -252,6 +253,7 @@ public class TestAbfsRestOperationMockFailures {
 
     TracingContext tracingContext = Mockito.mock(TracingContext.class);
     Mockito.doNothing().when(tracingContext).setRetryCount(nullable(int.class));
+    Mockito.doReturn(tracingContext).when(abfsRestOperation).createNewTracingContext(any());
 
     int[] count = new int[1];
     count[0] = 0;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
@@ -18,9 +18,7 @@
 
 package org.apache.hadoop.fs.azurebfs.services;
 
-import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.net.HttpURLConnection;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
@@ -41,7 +39,6 @@ import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceError
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.INGRESS_OVER_ACCOUNT_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil.addMockBehaviourToAbfsClient;
 import static org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil.addMockBehaviourToRestOpAndHttpOp;
-import static org.apache.hadoop.fs.azurebfs.services.AuthType.OAuth;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_MESSAGE;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_TIMEOUT_ABBREVIATION;

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/services/TestAbfsRestOperationMockFailures.java
@@ -39,6 +39,8 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.EGRESS_OVER_ACCOUNT_LIMIT;
 import static org.apache.hadoop.fs.azurebfs.contracts.services.AzureServiceErrorCode.INGRESS_OVER_ACCOUNT_LIMIT;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil.addMockBehaviourToAbfsClient;
+import static org.apache.hadoop.fs.azurebfs.services.AbfsClientTestUtil.addMockBehaviourToRestOpAndHttpOp;
 import static org.apache.hadoop.fs.azurebfs.services.AuthType.OAuth;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_ABBREVIATION;
 import static org.apache.hadoop.fs.azurebfs.services.RetryReasonConstants.CONNECTION_RESET_MESSAGE;
@@ -267,36 +269,5 @@ public class TestAbfsRestOperationMockFailures {
 
     abfsRestOperation.execute(tracingContext);
     Assertions.assertThat(count[0]).isEqualTo(len + 1);
-  }
-
-  private void addMockBehaviourToRestOpAndHttpOp(final AbfsRestOperation abfsRestOperation,
-      final AbfsHttpOperation httpOperation) throws IOException {
-    HttpURLConnection httpURLConnection = Mockito.mock(HttpURLConnection.class);
-    Mockito.doNothing()
-        .when(httpURLConnection)
-        .setRequestProperty(nullable(String.class), nullable(String.class));
-    Mockito.doReturn(httpURLConnection).when(httpOperation).getConnection();
-    Mockito.doReturn("").when(abfsRestOperation).getClientLatency();
-    Mockito.doReturn(httpOperation).when(abfsRestOperation).createHttpOperation();
-  }
-
-  private void addMockBehaviourToAbfsClient(final AbfsClient abfsClient,
-      final ExponentialRetryPolicy retryPolicy) throws IOException {
-    Mockito.doReturn(OAuth).when(abfsClient).getAuthType();
-    Mockito.doReturn("").when(abfsClient).getAccessToken();
-    AbfsThrottlingIntercept intercept = Mockito.mock(
-        AbfsThrottlingIntercept.class);
-    Mockito.doReturn(intercept).when(abfsClient).getIntercept();
-    Mockito.doNothing()
-        .when(intercept)
-        .sendingRequest(any(), nullable(AbfsCounters.class));
-    Mockito.doNothing().when(intercept).updateMetrics(any(), any());
-
-    Mockito.doReturn(retryPolicy).when(abfsClient).getRetryPolicy();
-    Mockito.doReturn(true)
-        .when(retryPolicy)
-        .shouldRetry(nullable(Integer.class), nullable(Integer.class));
-    Mockito.doReturn(false).when(retryPolicy).shouldRetry(1, HTTP_OK);
-    Mockito.doReturn(false).when(retryPolicy).shouldRetry(2, HTTP_OK);
   }
 }


### PR DESCRIPTION
:::: AGGREGATED TEST RESULT ::::

NonHNS-SharedKey
========================
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   TestTracingContext.testClientCorrelationId:67->checkCorrelationConfigValidation:131 [Client Request Header should match TracingContext] expected:<"[]"> but was:<"[valid-corr-id-123:5a4aac38-cfa9-4ef5-9f1b-f237ccdf0e5d:11b28a6b-fabe-41e9-9259-1612639043c2:::TS:0:B]">
[ERROR]   TestAbfsClientThrottlingAnalyzer.testManySuccessAndErrorsAndWaiting:181->fuzzyValidate:64 The actual value 10 is not within the expected range: [5.60, 8.40].
[INFO]
[ERROR] Tests run: 141, Failures: 2, Errors: 0, Skipped: 4
[INFO] Results:
[INFO]
[WARNING] Tests run: 794, Failures: 0, Errors: 0, Skipped: 275
[INFO] Results:
[INFO]
[WARNING] Tests run: 285, Failures: 0, Errors: 0, Skipped: 45

Time taken: 10 mins 47 secs.
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$
azureuser@Hadoop-VM-EAST2:~/hadoop/hadoop-tools/hadoop-azure$ git log
commit e5bd84c4b1a4761fc13dba681f65caaeff025b28 (HEAD -> listTracingContextFix-parallelop, origin/listTracingContextFix-parallelop)
Author: Pranav Saxena <>
Date:   Wed Aug 16 06:17:09 2023 -0700

    formating