### PR TITLE
new config: fs.azure.blob.implicit.check.enabled

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AbfsConfiguration.java
@@ -367,6 +367,10 @@ public class AbfsConfiguration{
       FS_AZURE_ENABLE_PAGINATED_DELETE, DefaultValue = DEFAULT_ENABLE_PAGINATED_DELETE)
   private boolean isPaginatedDeleteEnabled;
 
+  @BooleanConfigurationValidatorAnnotation(ConfigurationKey = FS_AZURE_BLOB_IMPLICIT_CHECK_ENABLED,
+      DefaultValue = DEFAULT_AZURE_BLOB_IMPLICIT_CHECK_ENABLED)
+  private boolean isBlobImplicitCheckEnabled;
+
   private String clientProvidedEncryptionKey;
   private String clientProvidedEncryptionKeySHA;
 
@@ -1241,6 +1245,10 @@ public class AbfsConfiguration{
 
   public boolean isPaginatedDeleteEnabled() {
     return isPaginatedDeleteEnabled;
+  }
+
+  public boolean isBlobImplicitCheckEnabled() {
+    return isBlobImplicitCheckEnabled;
   }
 
   public boolean getIsChecksumValidationEnabled() {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/ConfigurationKeys.java
@@ -309,5 +309,11 @@ public final class ConfigurationKeys {
    * @see FileSystem#openFile(org.apache.hadoop.fs.Path)
    */
   public static final String FS_AZURE_BUFFERED_PREAD_DISABLE = "fs.azure.buffered.pread.disable";
+
+  /**
+   * Specify if implicit directories (directories without marker blob)
+   * are possible in the FileSystem.{@value}
+   */
+  public static final String FS_AZURE_BLOB_IMPLICIT_CHECK_ENABLED = "fs.azure.blob.implicit.check.enabled";
   private ConfigurationKeys() {}
 }

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FileSystemConfigurations.java
@@ -161,5 +161,7 @@ public final class FileSystemConfigurations {
    */
   public static final int RATE_LIMIT_DEFAULT = 10_000;
 
+  public static final boolean DEFAULT_AZURE_BLOB_IMPLICIT_CHECK_ENABLED = true;
+
   private FileSystemConfigurations() {}
 }


### PR DESCRIPTION
Config to define if implicit directories are possibility in the filesystem. Enabled by default.