### PR TITLE
fs.contract.test.root-tests-enabled fix

### DIFF
--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/constants/TestConfigurationKeys.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/constants/TestConfigurationKeys.java
@@ -29,6 +29,7 @@ public final class TestConfigurationKeys {
   public static final String FS_AZURE_ANALYSIS_PERIOD = "fs.azure.analysis.period";
   public static final String FS_AZURE_ACCOUNT_KEY = "fs.azure.account.key";
   public static final String FS_AZURE_CONTRACT_TEST_URI = "fs.contract.test.fs.abfs";
+  public static final String FS_SECURE_AZURE_CONTRACT_TEST_URI = "fs.contract.test.fs.abfss";
   public static final String FS_AZURE_TEST_NAMESPACE_ENABLED_ACCOUNT = "fs.azure.test.namespace.enabled";
   public static final String FS_AZURE_TEST_APPENDBLOB_ENABLED = "fs.azure.test.appendblob.enabled";
   public static final String FS_AZURE_TEST_CPK_ENABLED = "fs.azure.test.cpk.enabled";

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
@@ -60,15 +60,11 @@ public class ITestAbfsFileSystemContractRootDirectory extends AbstractContractRo
 
     contractTestFs = conf.get(FS_SECURE_AZURE_CONTRACT_TEST_URI);
     conf.set(FS_SECURE_AZURE_CONTRACT_TEST_URI, addRootDirToken(contractTestFs));
-
-//    conf.get(FS_AZURE_CONTRACT_TEST_URI);
     return new AbfsFileSystemContract(conf, isSecure);
   }
 
-  private String addRootDirToken(String fsKey) {
-    String[] splits = fsKey.split("@");
-    fsKey = splits[0] + "-dir@" + splits[1];
-    return fsKey;
+  private String addRootDirToken(String configVal) {
+    return configVal.replaceFirst("@", "-dir@");
   }
 
   @Override

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/contract/ITestAbfsFileSystemContractRootDirectory.java
@@ -22,6 +22,10 @@ import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.junit.Ignore;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY;
+import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_AZURE_CONTRACT_TEST_URI;
+import static org.apache.hadoop.fs.azurebfs.constants.TestConfigurationKeys.FS_SECURE_AZURE_CONTRACT_TEST_URI;
+
 /**
  * Contract test for root directory operation.
  */
@@ -46,8 +50,25 @@ public class ITestAbfsFileSystemContractRootDirectory extends AbstractContractRo
   }
 
   @Override
-  protected AbstractFSContract createContract(final Configuration conf) {
+  protected AbstractFSContract createContract(Configuration conf) {
+    conf = new Configuration(conf);
+    String fsKey = conf.get(FS_DEFAULT_NAME_KEY);
+    conf.set(FS_DEFAULT_NAME_KEY, addRootDirToken(fsKey));
+
+    String contractTestFs = conf.get(FS_AZURE_CONTRACT_TEST_URI);
+    conf.set(FS_AZURE_CONTRACT_TEST_URI, addRootDirToken(contractTestFs));
+
+    contractTestFs = conf.get(FS_SECURE_AZURE_CONTRACT_TEST_URI);
+    conf.set(FS_SECURE_AZURE_CONTRACT_TEST_URI, addRootDirToken(contractTestFs));
+
+//    conf.get(FS_AZURE_CONTRACT_TEST_URI);
     return new AbfsFileSystemContract(conf, isSecure);
+  }
+
+  private String addRootDirToken(String fsKey) {
+    String[] splits = fsKey.split("@");
+    fsKey = splits[0] + "-dir@" + splits[1];
+    return fsKey;
   }
 
   @Override


### PR DESCRIPTION
Problem:

Right now on trunk, config fs.contract.test.root-tests-enabled has to be switched off as the root tests can interfere with the other contract tests.

Contract tests run on different JVMs but they share same container name. So, if the mentioned config is true, there are rootDelete tests, which can change state of any other contract test.

Fix:
We will change the container name for root-delete contract test: ITestAbfsFileSystemContractRootDirectory

PR on trunk shall be raised in future.


result:
------------------------------
:::: AGGREGATED TEST RESULT ::::

============================================================
HNS-OAuth
============================================================
[ERROR] testGetAclCallOnHnsConfigAbsence(org.apache.hadoop.fs.azurebfs.ITestAzureBlobFileSystemInitAndCreate)  Time elapsed: 9.453 s  <<< FAILURE!

[ERROR] testBackoffRetryMetrics(org.apache.hadoop.fs.azurebfs.services.TestAbfsRestOperation)  Time elapsed: 3.451 s  <<< ERROR!
[ERROR] testReadFooterMetrics(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 4.871 s  <<< ERROR!
[ERROR] testMetricWithIdlePeriod(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 4.866 s  <<< ERROR!
[ERROR] testReadFooterMetricsWithParquetAndNonParquet(org.apache.hadoop.fs.azurebfs.ITestAbfsReadFooterMetrics)  Time elapsed: 4.811 s  <<< ERROR!

[ERROR] Tests run: 142, Failures: 0, Errors: 1, Skipped: 2
[ERROR] Tests run: 625, Failures: 1, Errors: 3, Skipped: 76
[WARNING] Tests run: 412, Failures: 0, Errors: 0, Skipped: 48

Time taken: 7 mins 24 secs.
azureuser@pranav-ind-vm:~/AbfsHadoop/hadoop-tools/hadoop-azure$ git log
commit b2ac2669d9df75eb03cc247ec599d0794463689d (HEAD -> rootDirResolution, origin/rootDirResolution)
Author: Pranav Saxena <>
Date:   Tue Jun 18 01:45:37 2024 -0700

    fs.contract.test.fs.abfss




azureuser@pranav-ind-vm:~/AbfsHadoop/hadoop-tools/hadoop-azure$ cat src/test/resources/abfs.xml
```
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one
  ~  or more contributor license agreements.  See the NOTICE file
  ~  distributed with this work for additional information
  ~  regarding copyright ownership.  The ASF licenses this file
  ~  to you under the Apache License, Version 2.0 (the
  ~  "License"); you may not use this file except in compliance
  ~  with the License.  You may obtain a copy of the License at
  ~
  ~       http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~  Unless required by applicable law or agreed to in writing, software
  ~  distributed under the License is distributed on an "AS IS" BASIS,
  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~  See the License for the specific language governing permissions and
  ~  limitations under the License.
  -->
<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
    <property>
        <name>fs.contract.test.root-tests-enabled</name>
        <value>true</value>
    </property>
```