### PR TITLE
[FnsOverBlob] Fixing HNS-Blob Init Failure Error.

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystem.java
@@ -213,19 +213,22 @@ public class AzureBlobFileSystem extends FileSystem
 
     TracingContext tracingContext = new TracingContext(clientCorrelationId,
             fileSystemId, FSOperationType.CREATE_FILESYSTEM, tracingHeaderFormat, listener);
-    // Check if valid service type is configured.
-    abfsConfiguration.validateConfiguredServiceType(
-        getIsNamespaceEnabled(new TracingContext(tracingContext)));
-
     if (abfsConfiguration.getCreateRemoteFileSystemDuringInitialization()) {
       if (this.tryGetFileStatus(new Path(AbfsHttpConstants.ROOT_PATH), tracingContext) == null) {
         try {
           this.createFileSystem(tracingContext);
         } catch (AzureBlobFileSystemException ex) {
           checkException(null, ex, AzureServiceErrorCode.FILE_SYSTEM_ALREADY_EXISTS);
+        } catch (UnsupportedOperationException ex) {
+          abfsConfiguration.validateConfiguredServiceType(
+              getIsNamespaceEnabled(new TracingContext(tracingContext)));
         }
       }
     }
+
+    // Check if valid service type is configured.
+    abfsConfiguration.validateConfiguredServiceType(
+        getIsNamespaceEnabled(new TracingContext(tracingContext)));
 
     /*
      * Non-hierarchical-namespace account can not have a customer-provided-key(CPK).

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FSOperationType.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/constants/FSOperationType.java
@@ -45,8 +45,7 @@ public enum FSOperationType {
     SET_OWNER("SO"),
     SET_ACL("SA"),
     TEST_OP("TS"),
-    WRITE("WR"),
-    INIT("IN");
+    WRITE("WR");
 
     private final String opCode;
 


### PR DESCRIPTION
### Description of PR
When hns account is configured with Blob Endpoint, file system init should fail even before trying to create a filesystem(container) on store.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

