### PR TITLE
Add clientRequestId of previous failed request to the primaryRequestId of the retried request

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java
@@ -1865,7 +1865,7 @@ public class AzureBlobFileSystemStore implements Closeable, ListingSupport {
     return AbfsServiceType.DFS;
   }
 
-  private AbfsServiceType getConfiguredServiceType() {
+  public AbfsServiceType getConfiguredServiceType() {
     return abfsConfiguration.getFsConfiguredServiceType();
   }
 

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -226,7 +226,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = new AbfsUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.CreateContainer,
@@ -258,7 +258,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, METADATA);
-
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.SetContainerMetadata,
@@ -281,7 +281,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetContainerProperties,
@@ -304,7 +304,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.DeleteContainer,
@@ -454,6 +454,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     appendSASTokenToQuery(path, SASTokenProvider.CREATE_FILE_OPERATION, abfsUriQueryBuilder);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlob,
@@ -594,6 +595,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, APPEND_BLOCK);
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.APPEND_BLOCK_OPERATION, abfsUriQueryBuilder);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.AppendBlock,
@@ -653,6 +655,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_MAX_RESULTS, String.valueOf(listMaxResults));
     appendSASTokenToQuery(relativePath, SASTokenProvider.LIST_BLOB_OPERATION, abfsUriQueryBuilder);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.ListBlobs,
@@ -739,6 +742,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -765,6 +769,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -791,6 +796,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -816,6 +822,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -914,6 +921,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.READ_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
+    tracingContext.setPrimaryRequestIDBlob();
     URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetBlob,
@@ -979,6 +987,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlock,
@@ -1083,6 +1092,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlockList,
@@ -1137,6 +1147,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, METADATA);
     appendSASTokenToQuery(path, SASTokenProvider.SET_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.SetPathProperties,
@@ -1156,6 +1167,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(HttpQueryParams.QUERY_PARAM_UPN, String.valueOf(abfsConfiguration.isUpnUsed()));
     appendSASTokenToQuery(path, SASTokenProvider.GET_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetBlobProperties,
@@ -1345,6 +1357,8 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCKLIST);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKLISTTYPE, BLOCK_TYPE_COMMITTED);
+
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
 
     final AbfsRestOperation op = getAbfsRestOperation(
@@ -1382,6 +1396,8 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
         SASTokenProvider.WRITE_OPERATION, abfsUriQueryBuilderDst);
     appendSASTokenToQuery(srcBlobRelativePath,
         SASTokenProvider.READ_OPERATION, abfsUriQueryBuilderSrc);
+
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(dstBlobRelativePath,
         abfsUriQueryBuilderDst.toString());
     final String sourcePathUrl = createRequestUrl(srcBlobRelativePath,
@@ -1417,6 +1433,8 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String blobRelativePath = blobPath.toUri().getPath();
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.DELETE_OPERATION, abfsUriQueryBuilder);
+
+    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(blobRelativePath, abfsUriQueryBuilder.toString());
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     if(leaseId != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/services/AbfsBlobClient.java
@@ -227,7 +227,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = new AbfsUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-    tracingContext.setPrimaryRequestIDBlob();
+
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.CreateContainer,
@@ -259,7 +259,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, METADATA);
-    tracingContext.setPrimaryRequestIDBlob();
+
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.SetContainerMetadata,
@@ -282,7 +282,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-    tracingContext.setPrimaryRequestIDBlob();
+
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetContainerProperties,
@@ -305,7 +305,7 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_RESTYPE, CONTAINER);
-    tracingContext.setPrimaryRequestIDBlob();
+
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.DeleteContainer,
@@ -455,7 +455,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     appendSASTokenToQuery(path, SASTokenProvider.CREATE_FILE_OPERATION, abfsUriQueryBuilder);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlob,
@@ -596,7 +595,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, APPEND_BLOCK);
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.APPEND_BLOCK_OPERATION, abfsUriQueryBuilder);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.AppendBlock,
@@ -656,7 +654,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_MAX_RESULTS, String.valueOf(listMaxResults));
     appendSASTokenToQuery(relativePath, SASTokenProvider.LIST_BLOB_OPERATION, abfsUriQueryBuilder);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.ListBlobs,
@@ -743,7 +740,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -770,7 +766,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -797,7 +792,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -823,7 +817,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     final AbfsUriQueryBuilder abfsUriQueryBuilder = createDefaultUriQueryBuilder();
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, LEASE);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.LeaseBlob,
@@ -924,7 +917,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.READ_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
-    tracingContext.setPrimaryRequestIDBlob();
     URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetBlob,
@@ -990,7 +982,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlock,
@@ -1095,7 +1086,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String sasTokenForReuse = appendSASTokenToQuery(path, SASTokenProvider.WRITE_OPERATION,
         abfsUriQueryBuilder, cachedSasToken);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.PutBlockList,
@@ -1150,7 +1140,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, METADATA);
     appendSASTokenToQuery(path, SASTokenProvider.SET_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.SetPathProperties,
@@ -1189,7 +1178,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     abfsUriQueryBuilder.addQuery(HttpQueryParams.QUERY_PARAM_UPN, String.valueOf(abfsConfiguration.isUpnUsed()));
     appendSASTokenToQuery(path, SASTokenProvider.GET_PROPERTIES_OPERATION, abfsUriQueryBuilder);
 
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
     final AbfsRestOperation op = getAbfsRestOperation(
         AbfsRestOperationType.GetBlobProperties,
@@ -1376,8 +1364,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
 
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_COMP, BLOCKLIST);
     abfsUriQueryBuilder.addQuery(QUERY_PARAM_BLOCKLISTTYPE, BLOCK_TYPE_COMMITTED);
-
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(path, abfsUriQueryBuilder.toString());
 
     final AbfsRestOperation op = getAbfsRestOperation(
@@ -1415,8 +1401,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
         SASTokenProvider.WRITE_OPERATION, abfsUriQueryBuilderDst);
     appendSASTokenToQuery(srcBlobRelativePath,
         SASTokenProvider.READ_OPERATION, abfsUriQueryBuilderSrc);
-
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(dstBlobRelativePath,
         abfsUriQueryBuilderDst.toString());
     final String sourcePathUrl = createRequestUrl(srcBlobRelativePath,
@@ -1452,8 +1436,6 @@ public class AbfsBlobClient extends AbfsClient implements Closeable {
     String blobRelativePath = blobPath.toUri().getPath();
     appendSASTokenToQuery(blobRelativePath,
         SASTokenProvider.DELETE_OPERATION, abfsUriQueryBuilder);
-
-    tracingContext.setPrimaryRequestIDBlob();
     final URL url = createRequestUrl(blobRelativePath, abfsUriQueryBuilder.toString());
     final List<AbfsHttpHeader> requestHeaders = createDefaultHeaders();
     if(leaseId != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -153,6 +153,24 @@ public class TracingContext {
     return clientCorrelationID;
   }
 
+  public void setPrimaryRequestIDBlob() {
+    // Generate a UUID, remove dashes, and shuffle by selecting a random 8-character substring
+    String uuid = UUID.randomUUID().toString().replace("-", "");
+    StringBuilder randomId = new StringBuilder(8);
+
+    for (int i = 0; i < 8; i++) {
+      int randomIndex = (int) (Math.random() * uuid.length());
+      randomId.append(uuid.charAt(randomIndex));
+    }
+
+    primaryRequestId = randomId.toString();
+
+    // If a listener is available, update it with the new primaryRequestId
+    if (listener != null) {
+      listener.updatePrimaryRequestID(primaryRequestId);
+    }
+  }
+
   public void setPrimaryRequestID() {
     primaryRequestId = UUID.randomUUID().toString();
     if (listener != null) {

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -153,18 +153,31 @@ public class TracingContext {
     return clientCorrelationID;
   }
 
+  /**
+   * Generates a random substring of a specified length from the given input string.
+   * The substring is created by randomly selecting characters from the input string.
+   *
+   * @param input  The input string from which the random substring will be generated.
+   *               This string should be long enough to allow for sufficient randomness.
+   * @param length The desired length of the random substring to be generated.
+   *               This should be a positive integer less than or equal to the length of the input string.
+   * @return A randomly generated substring of the specified length.
+   * @throws IllegalArgumentException if the length parameter is greater than the input string's length.
+   */
+  public String generateRandomId(String input, int length) {
+    StringBuilder randomId = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      int randomIndex = (int) (Math.random() * input.length());
+      randomId.append(input.charAt(randomIndex));
+    }
+    return randomId.toString();
+  }
+
+
   public void setPrimaryRequestIDBlob() {
     // Generate a UUID, remove dashes, and shuffle by selecting a random 8-character substring
     String uuid = UUID.randomUUID().toString().replace("-", "");
-    StringBuilder randomId = new StringBuilder(8);
-
-    for (int i = 0; i < 8; i++) {
-      int randomIndex = (int) (Math.random() * uuid.length());
-      randomId.append(uuid.charAt(randomIndex));
-    }
-
-    primaryRequestId = randomId + "B";
-
+    primaryRequestId = generateRandomId(uuid, 8) + "B";
     // If a listener is available, update it with the new primaryRequestId
     if (listener != null) {
       listener.updatePrimaryRequestID(primaryRequestId);

--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/utils/TracingContext.java
@@ -251,7 +251,7 @@ public class TracingContext {
     * UUID in primaryRequestIdForRetry. This field shall be used as primaryRequestId part
     * of the x-ms-client-request-id header in case of retry of the same API-request.
     */
-    if (!primaryRequestId.isEmpty() && primaryRequestId.contains("B")) {
+    if (primaryRequestId.contains("B")) {
       String[] clientRequestIdParts = clientRequestId.split("-");
       primaryRequestIdForRetry = primaryRequestId + "_" + clientRequestIdParts[
               clientRequestIdParts.length - 1];

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -283,6 +283,42 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
   }
 
   @Test
+  public void testRetryPrimaryRequestIdBlob() throws Exception {
+    final AzureBlobFileSystem fs = getFileSystem();
+    final String fileSystemId = fs.getFileSystemId();
+    final String clientCorrelationId = fs.getClientCorrelationId();
+    final TracingHeaderFormat tracingHeaderFormat = TracingHeaderFormat.ALL_ID_FORMAT;
+    TracingContext tracingContext = new TracingContext(clientCorrelationId,
+            fileSystemId, FSOperationType.CREATE_FILESYSTEM, tracingHeaderFormat, new TracingHeaderValidator(
+            fs.getAbfsStore().getAbfsConfiguration().getClientCorrelationId(),
+            fs.getFileSystemId(), FSOperationType.CREATE_FILESYSTEM, false,
+            0));
+    tracingContext.setPrimaryRequestIDBlob();
+    AbfsHttpOperation abfsHttpOperation = Mockito.mock(AbfsHttpOperation.class);
+    Mockito.doNothing().when(abfsHttpOperation).setRequestProperty(Mockito.anyString(), Mockito.anyString());
+    tracingContext.constructHeader(abfsHttpOperation, null, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
+    String header = tracingContext.getHeader();
+    String[] clientRequestIdParts = header.split(":")[1].split("-");
+    String clientRequestId = clientRequestIdParts[clientRequestIdParts.length - 1];
+    String assertionPrimaryId = header.split(":")[3];
+
+    tracingContext.setRetryCount(1);
+    tracingContext.setListener(new TracingHeaderValidator(
+            fs.getAbfsStore().getAbfsConfiguration().getClientCorrelationId(),
+            fs.getFileSystemId(), FSOperationType.CREATE_FILESYSTEM, false,
+            1));
+
+    tracingContext.constructHeader(abfsHttpOperation, READ_TIMEOUT_ABBREVIATION, EXPONENTIAL_RETRY_POLICY_ABBREVIATION);
+    header = tracingContext.getHeader();
+    String primaryRequestId = header.split(":")[3];
+
+    Assertions.assertThat(primaryRequestId)
+            .describedAs("PrimaryRequestId in a retried request's tracingContext "
+                    + "should be equal to PrimaryRequestId in the original request.")
+            .isEqualTo(assertionPrimaryId + "_" + clientRequestId);
+  }
+
+  @Test
   public void testTracingContextHeaderForRetrypolicy() throws Exception {
     final AzureBlobFileSystem fs = getFileSystem();
     final String fileSystemId = fs.getFileSystemId();

--- a/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
+++ b/hadoop-tools/hadoop-azure/src/test/java/org/apache/hadoop/fs/azurebfs/TestTracingContext.java
@@ -314,7 +314,8 @@ public class TestTracingContext extends AbstractAbfsIntegrationTest {
 
     Assertions.assertThat(primaryRequestId)
             .describedAs("PrimaryRequestId in a retried request's tracingContext "
-                    + "should be equal to PrimaryRequestId in the original request.")
+                    + "should be equal to PrimaryRequestId in the original request along with the last part" +
+                    "of clientRequestId of the first request")
             .isEqualTo(assertionPrimaryId + "_" + clientRequestId);
   }
 


### PR DESCRIPTION
1. Sets a primaryRequestId for all Blob API's
2. Generates a random 8 character UUID by shuffling and sets it to the primaryRequestId.
3. For every retried request, set the primaryRequestId as primaryRequestId_lastpartofclientRequestId of first request.